### PR TITLE
ci: deploy job waits for E2E to pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
+    needs: [build, e2e]
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Deploy now depends on both `build` and `e2e` jobs, not just `build`. This ensures broken E2E tests block deployment to GitHub Pages.

Also added branch protection on `main`: both `build` and `e2e` checks must pass before merge.