### PR TITLE
feat(a11y): keyboard-based goal card reorder

### DIFF
--- a/src/pages/goal/components/GoalsMiniGrid.test.tsx
+++ b/src/pages/goal/components/GoalsMiniGrid.test.tsx
@@ -788,4 +788,188 @@ describe('GoalsMiniGrid', () => {
     expect(grid).toBeInTheDocument()
     expect(grid).toHaveAttribute('aria-label', 'Select goals for comparison')
   })
+
+  /* ── Keyboard-based reorder (grab handle) #109 ─────────────────── */
+
+  describe('keyboard reorder via grab handle', () => {
+    it('renders a grab handle for each goal card', () => {
+      const props = defaultProps()
+      render(<GoalsMiniGrid {...props} />)
+
+      expect(screen.getByRole('button', { name: /reorder alpha/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /reorder beta/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /reorder gamma/i })).toBeInTheDocument()
+    })
+
+    it('does not render grab handles when onReorderGoals is undefined', () => {
+      const props = defaultProps()
+      render(<GoalsMiniGrid {...props} onReorderGoals={undefined} />)
+
+      expect(screen.queryByRole('button', { name: /reorder/i })).not.toBeInTheDocument()
+    })
+
+    it('enters grabbed mode on click with aria-pressed true and announcement', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      const { container } = render(<GoalsMiniGrid {...props} />)
+
+      const handle = screen.getByRole('button', { name: /reorder beta/i })
+      await user.click(handle)
+
+      expect(handle).toHaveAttribute('aria-pressed', 'true')
+      const liveRegion = container.querySelector('[aria-live="polite"]')
+      expect(liveRegion?.textContent).toContain('grabbed')
+      expect(liveRegion?.textContent).toContain('Beta')
+    })
+
+    it('moves card right with ArrowRight in grid mode', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      render(<GoalsMiniGrid {...props} viewMode="grid" />)
+
+      const handle = screen.getByRole('button', { name: /reorder beta/i })
+      await user.click(handle)
+      await user.keyboard('{ArrowRight}')
+
+      expect(props.onReorderGoals).toHaveBeenCalledWith([1, 3, 2])
+    })
+
+    it('moves card down with ArrowDown in list mode', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      render(<GoalsMiniGrid {...props} viewMode="list" />)
+
+      const handle = screen.getByRole('button', { name: /reorder beta/i })
+      await user.click(handle)
+      await user.keyboard('{ArrowDown}')
+
+      expect(props.onReorderGoals).toHaveBeenCalledWith([1, 3, 2])
+    })
+
+    it('does not move first card when pressing ArrowLeft in grid mode', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      render(<GoalsMiniGrid {...props} viewMode="grid" />)
+
+      const handle = screen.getByRole('button', { name: /reorder alpha/i })
+      await user.click(handle)
+      await user.keyboard('{ArrowLeft}')
+
+      expect(props.onReorderGoals).not.toHaveBeenCalled()
+    })
+
+    it('does not move last card when pressing ArrowRight in grid mode', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      render(<GoalsMiniGrid {...props} viewMode="grid" />)
+
+      const handle = screen.getByRole('button', { name: /reorder gamma/i })
+      await user.click(handle)
+      await user.keyboard('{ArrowRight}')
+
+      expect(props.onReorderGoals).not.toHaveBeenCalled()
+    })
+
+    it('drops card on Enter and clears grabbed state', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      const { container } = render(<GoalsMiniGrid {...props} />)
+
+      const handle = screen.getByRole('button', { name: /reorder beta/i })
+      await user.click(handle)
+      expect(handle).toHaveAttribute('aria-pressed', 'true')
+
+      await user.keyboard('{Enter}')
+
+      expect(handle).toHaveAttribute('aria-pressed', 'false')
+      const liveRegion = container.querySelector('[aria-live="polite"]')
+      expect(liveRegion?.textContent).toContain('dropped')
+    })
+
+    it('drops card on Space and clears grabbed state', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      const { container } = render(<GoalsMiniGrid {...props} />)
+
+      const handle = screen.getByRole('button', { name: /reorder beta/i })
+      await user.click(handle)
+      await user.keyboard(' ')
+
+      expect(handle).toHaveAttribute('aria-pressed', 'false')
+      const liveRegion = container.querySelector('[aria-live="polite"]')
+      expect(liveRegion?.textContent).toContain('dropped')
+    })
+
+    it('cancels reorder on Escape and restores original order', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      const { container, rerender } = render(<GoalsMiniGrid {...props} />)
+
+      const handle = screen.getByRole('button', { name: /reorder beta/i })
+      await user.click(handle)
+      await user.keyboard('{ArrowRight}')
+
+      // Simulate parent re-rendering with new order after onReorderGoals
+      const reorderedGoals = [defaultGoals[0], defaultGoals[2], defaultGoals[1]]
+      rerender(<GoalsMiniGrid {...props} goals={reorderedGoals} />)
+
+      // Now press Escape to cancel — focus followed Beta to new position
+      screen.getByRole('button', { name: /grabbed/i })
+      await user.keyboard('{Escape}')
+
+      // Should restore original order [1,2,3]
+      const calls = props.onReorderGoals.mock.calls
+      const lastCall = calls[calls.length - 1][0]
+      expect(lastCall).toEqual([1, 2, 3])
+
+      const liveRegion = container.querySelector('[aria-live="polite"]')
+      expect(liveRegion?.textContent).toContain('cancelled')
+    })
+
+    it('announces correct text for grab, move, and drop', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      const { container } = render(<GoalsMiniGrid {...props} viewMode="grid" />)
+      const liveRegion = container.querySelector('[aria-live="polite"]')!
+
+      // Grab
+      const handle = screen.getByRole('button', { name: /reorder beta/i })
+      await user.click(handle)
+      expect(liveRegion.textContent).toContain('Beta grabbed')
+      expect(liveRegion.textContent).toContain('Position 2 of 3')
+
+      // Move
+      await user.keyboard('{ArrowRight}')
+      expect(liveRegion.textContent).toContain('Beta moved after Gamma')
+    })
+
+    it('announces dropped text on Enter without prior move', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      const { container } = render(<GoalsMiniGrid {...props} />)
+      const liveRegion = container.querySelector('[aria-live="polite"]')!
+
+      const handle = screen.getByRole('button', { name: /reorder beta/i })
+      await user.click(handle)
+      await user.keyboard('{Enter}')
+
+      expect(liveRegion.textContent).toContain('Beta dropped at position 2 of 3')
+    })
+
+    it('does not render grab handle during rename', async () => {
+      const user = userEvent.setup()
+      const props = defaultProps()
+      render(<GoalsMiniGrid {...props} />)
+
+      // Start rename via context menu
+      const alphaCard = screen.getByText('Alpha').closest('.goal-drag-item')!
+      fireEvent.contextMenu(alphaCard, { clientX: 100, clientY: 200 })
+      await user.click(screen.getByText('Rename'))
+
+      // Grab handle for Alpha should not be visible
+      expect(screen.queryByRole('button', { name: /reorder alpha/i })).not.toBeInTheDocument()
+      // Other grab handles still present
+      expect(screen.getByRole('button', { name: /reorder beta/i })).toBeInTheDocument()
+    })
+  })
 })

--- a/src/pages/goal/components/GoalsMiniGrid.tsx
+++ b/src/pages/goal/components/GoalsMiniGrid.tsx
@@ -43,10 +43,14 @@ const GoalsMiniGrid: FC<GoalsMiniGridProps> = ({
   const [renamingId, setRenamingId] = useState<number | null>(null)
   const [renameValue, setRenameValue] = useState('')
   const [announcement, setAnnouncement] = useState('')
+  const [grabbedIndex, setGrabbedIndex] = useState<number | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
   const gridRef = useRef<HTMLDivElement>(null)
   const touchMovedFlag = useRef(false)
+  const preGrabOrderRef = useRef<number[]>([])
+  const grabbedGoalId = useRef<number | null>(null)
+  const grabHandleRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
 
   useEffect(() => {
     if (!contextMenu) return
@@ -60,6 +64,13 @@ const GoalsMiniGrid: FC<GoalsMiniGridProps> = ({
   useEffect(() => {
     if (renamingId !== null) renameInputRef.current?.focus()
   }, [renamingId])
+
+  useEffect(() => {
+    if (grabbedGoalId.current !== null) {
+      const btn = grabHandleRefs.current.get(grabbedGoalId.current)
+      if (btn) btn.focus()
+    }
+  }, [grabbedIndex])
 
   const openContextMenu = (e: React.MouseEvent, goalId: number) => {
     if (touchMovedFlag.current) {
@@ -257,6 +268,7 @@ const GoalsMiniGrid: FC<GoalsMiniGridProps> = ({
           let itemClass = 'goal-drag-item'
           if (draggedId === goal.id) itemClass += ' goal-drag-item--dragging'
           else if (dragOverId === goal.id) itemClass += ` goal-drag-item--drag-${dragOverSide}`
+          if (grabbedIndex === goalIdx) itemClass += ' goal-drag-item--grabbed'
           if (touchDrag.isDragging && touchDraggedId.current === goal.id) itemClass += ' goal-drag-item--touch-dragging'
           if (touchDrag.isLongPressing && touchDrag.dragIdx === goalIdx) itemClass += ' goal-drag-item--long-press'
           const canDrag = !!onReorderGoals && renamingId !== goal.id
@@ -275,6 +287,70 @@ const GoalsMiniGrid: FC<GoalsMiniGridProps> = ({
               onTouchMove={touchHandlers?.onTouchMove}
               onTouchEnd={touchHandlers?.onTouchEnd}
             >
+              {onReorderGoals && renamingId !== goal.id && (
+                <button
+                  className="goal-grab-handle"
+                  ref={el => {
+                    if (el) grabHandleRefs.current.set(goal.id, el)
+                    else grabHandleRefs.current.delete(goal.id)
+                  }}
+                  aria-label={
+                    grabbedIndex === goalIdx
+                      ? `${goal.goalName}, grabbed. Use arrow keys to move, Enter to drop, Escape to cancel`
+                      : `Reorder ${goal.goalName}`
+                  }
+                  aria-pressed={grabbedIndex === goalIdx}
+                  onClick={() => {
+                    if (grabbedIndex === goalIdx) {
+                      grabbedGoalId.current = null
+                      setGrabbedIndex(null)
+                      setAnnouncement(`${goal.goalName} dropped at position ${goalIdx + 1} of ${goals.length}`)
+                    } else {
+                      preGrabOrderRef.current = goals.map(g => g.id)
+                      grabbedGoalId.current = goal.id
+                      setGrabbedIndex(goalIdx)
+                      setAnnouncement(
+                        `${goal.goalName} grabbed. Position ${goalIdx + 1} of ${goals.length}. Use arrow keys to move.`,
+                      )
+                    }
+                  }}
+                  onKeyDown={e => {
+                    if (grabbedIndex !== goalIdx) return
+                    const isHoriz = viewMode === 'grid'
+                    const prevKey = isHoriz ? 'ArrowLeft' : 'ArrowUp'
+                    const nextKey = isHoriz ? 'ArrowRight' : 'ArrowDown'
+
+                    if (e.key === prevKey && goalIdx > 0) {
+                      e.preventDefault()
+                      moveGoal(goalIdx, -1)
+                      setGrabbedIndex(goalIdx - 1)
+                    } else if (e.key === nextKey && goalIdx < goals.length - 1) {
+                      e.preventDefault()
+                      moveGoal(goalIdx, 1)
+                      setGrabbedIndex(goalIdx + 1)
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault()
+                      const goalId = goal.id
+                      onReorderGoals?.(preGrabOrderRef.current)
+                      setGrabbedIndex(null)
+                      setAnnouncement(`Reorder cancelled. ${goal.goalName} returned to original position.`)
+                      // Defer clearing grabbedGoalId so focus effect restores focus after re-render
+                      requestAnimationFrame(() => {
+                        const btn = grabHandleRefs.current.get(goalId)
+                        if (btn) btn.focus()
+                        grabbedGoalId.current = null
+                      })
+                    } else if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      grabbedGoalId.current = null
+                      setGrabbedIndex(null)
+                      setAnnouncement(`${goal.goalName} dropped at position ${goalIdx + 1} of ${goals.length}`)
+                    }
+                  }}
+                >
+                  ⠿
+                </button>
+              )}
               {onReorderGoals && renamingId !== goal.id && (
                 <div className="reorder-touch-controls goal-reorder-touch-controls">
                   <button

--- a/src/styles/Goal.css
+++ b/src/styles/Goal.css
@@ -515,6 +515,57 @@ body.dark .goal-drag-item--long-press {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
 }
 
+/* Keyboard grab handle — visible on hover/focus on desktop, hidden on mobile */
+.goal-grab-handle {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  cursor: grab;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0;
+  opacity: 0;
+  transition: opacity 150ms ease-out;
+  z-index: 1;
+}
+
+.goal-drag-item:hover .goal-grab-handle,
+.goal-grab-handle:focus-visible {
+  opacity: 1;
+}
+
+.goal-grab-handle[aria-pressed='true'] {
+  opacity: 1;
+  background: var(--accent-lighter, var(--color-surface-alt));
+  border-color: var(--accent, var(--color-border));
+  color: var(--accent, var(--color-text));
+  cursor: grabbing;
+}
+
+/* Grabbed card visual state */
+.goal-drag-item--grabbed {
+  outline: 2px solid var(--accent, #3b82f6);
+  outline-offset: 2px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  z-index: 10;
+  position: relative;
+}
+
+@media (max-width: 900px) {
+  .goal-grab-handle {
+    display: none;
+  }
+}
+
 /* Toolbar: filters + count + view toggle */
 .goal-toolbar {
   display: flex;


### PR DESCRIPTION
## Keyboard-based goal card reorder (#109)

Adds keyboard reorder to goal cards (WCAG 2.1 AA SC 2.1.1):
- Grab handle button on each card (visible on hover/focus)
- Enter/Space to grab/drop, arrow keys to move, Escape to cancel
- aria-live announcements for grab, move, drop, cancel
- Focus management retains focus on grabbed card after reorder
- Visual grabbed state (outline + elevated shadow)
- Hidden on mobile ≤900px (touch controls remain)
- 13 new unit tests (66 total for GoalsMiniGrid)

Fixes #109