### PR TITLE
feat: cross-tab localStorage sync for goals, profile, and settings

### DIFF
--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
 import { renderHook } from '@testing-library/react'
 import { SettingsProvider, useSettings } from './SettingsContext'
+import { appStorage } from '../utils/appStorage'
 
 /* ── helpers ─────────────────────────────────────────────────────── */
 
@@ -172,5 +173,111 @@ describe('SettingsContext', () => {
     expect(() => {
       renderHook(() => useSettings())
     }).toThrow('useSettings must be used within a <SettingsProvider>')
+  })
+})
+
+describe('SettingsContext cross-tab sync', () => {
+  let subscribeSpy: ReturnType<typeof vi.spyOn>
+  let capturedCallbacks: Map<string, (value: string | null) => void>
+  let unsubs: ReturnType<typeof vi.fn>[]
+
+  beforeEach(() => {
+    localStorage.clear()
+    document.body.classList.remove('dark')
+    capturedCallbacks = new Map()
+    unsubs = []
+    subscribeSpy = vi.spyOn(appStorage, 'subscribe').mockImplementation((key, cb) => {
+      capturedCallbacks.set(key, cb)
+      const unsub = vi.fn()
+      unsubs.push(unsub)
+      return unsub
+    })
+  })
+
+  afterEach(() => {
+    subscribeSpy.mockRestore()
+  })
+
+  it('subscribes to darkMode, accentTheme, and allowCsvImport on mount', () => {
+    render(
+      <SettingsProvider>
+        <Consumer />
+      </SettingsProvider>,
+    )
+    expect(subscribeSpy).toHaveBeenCalledWith('darkMode', expect.any(Function))
+    expect(subscribeSpy).toHaveBeenCalledWith('accentTheme', expect.any(Function))
+    expect(subscribeSpy).toHaveBeenCalledWith('allowCsvImport', expect.any(Function))
+  })
+
+  it('updates darkMode when subscriber fires with 1', () => {
+    render(
+      <SettingsProvider>
+        <Consumer />
+      </SettingsProvider>,
+    )
+    expect(screen.getByTestId('darkMode').textContent).toBe('false')
+
+    act(() => {
+      capturedCallbacks.get('darkMode')!('1')
+    })
+
+    expect(screen.getByTestId('darkMode').textContent).toBe('true')
+  })
+
+  it('updates darkMode to false when subscriber fires with 0', () => {
+    localStorage.setItem('darkMode', '1')
+    render(
+      <SettingsProvider>
+        <Consumer />
+      </SettingsProvider>,
+    )
+    expect(screen.getByTestId('darkMode').textContent).toBe('true')
+
+    act(() => {
+      capturedCallbacks.get('darkMode')!('0')
+    })
+
+    expect(screen.getByTestId('darkMode').textContent).toBe('false')
+  })
+
+  it('updates accentTheme when subscriber fires with new theme', () => {
+    render(
+      <SettingsProvider>
+        <Consumer />
+      </SettingsProvider>,
+    )
+    expect(screen.getByTestId('accentTheme').textContent).toBe('blue')
+
+    act(() => {
+      capturedCallbacks.get('accentTheme')!('purple')
+    })
+
+    expect(screen.getByTestId('accentTheme').textContent).toBe('purple')
+  })
+
+  it('updates allowCsvImport when subscriber fires with 1', () => {
+    render(
+      <SettingsProvider>
+        <Consumer />
+      </SettingsProvider>,
+    )
+    expect(screen.getByTestId('allowCsvImport').textContent).toBe('false')
+
+    act(() => {
+      capturedCallbacks.get('allowCsvImport')!('1')
+    })
+
+    expect(screen.getByTestId('allowCsvImport').textContent).toBe('true')
+  })
+
+  it('unsubscribes all on unmount', () => {
+    const { unmount } = render(
+      <SettingsProvider>
+        <Consumer />
+      </SettingsProvider>,
+    )
+    unsubs.forEach(fn => expect(fn).not.toHaveBeenCalled())
+    unmount()
+    unsubs.forEach(fn => expect(fn).toHaveBeenCalled())
   })
 })

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect, useMemo, FC, ReactNode, Dispatch, SetStateAction } from 'react'
 import { getStorageItem, setStorageItem } from '../utils/storage'
+import { appStorage } from '../utils/appStorage'
 
 export interface SettingsContextValue {
   darkMode: boolean
@@ -40,6 +41,23 @@ export const SettingsProvider: FC<{ children: ReactNode }> = ({ children }) => {
     if (typeof window === 'undefined') return false
     return getStorageItem('allowCsvImport', '0') === '1'
   })
+
+  // Cross-tab sync: react to settings changes from other tabs
+  useEffect(() => {
+    const unsubs = [
+      appStorage.subscribe('darkMode', val => {
+        if (val === '1') setDarkMode(true)
+        else if (val === '0') setDarkMode(false)
+      }),
+      appStorage.subscribe('accentTheme', val => {
+        if (val) setAccentTheme(val as string)
+      }),
+      appStorage.subscribe('allowCsvImport', val => {
+        setAllowCsvImport(val === '1')
+      }),
+    ]
+    return () => unsubs.forEach(fn => fn())
+  }, [])
 
   useEffect(() => {
     if (typeof window === 'undefined') return

--- a/src/hooks/useProfile.test.ts
+++ b/src/hooks/useProfile.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { Profile } from './useProfile'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useProfile, Profile } from './useProfile'
 import { appStorage } from '../utils/appStorage'
 
 const STORAGE_KEY = 'user-profile'
@@ -62,5 +63,56 @@ describe('Profile loading logic', () => {
     const profile = appStorage.getJSON<Profile>(STORAGE_KEY, { name: '', avatarDataUrl: '', birthday: '' })
     expect(profile.name).toBe('Solo')
     expect(profile.partner).toBeNull()
+  })
+})
+
+describe('useProfile cross-tab sync', () => {
+  let subscribeSpy: ReturnType<typeof vi.spyOn>
+  let capturedCallback: ((value: string | null) => void) | undefined
+  let unsub: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    capturedCallback = undefined
+    unsub = vi.fn()
+    subscribeSpy = vi.spyOn(appStorage, 'subscribe').mockImplementation((key, cb) => {
+      if (key === 'user-profile') capturedCallback = cb
+      return unsub
+    })
+  })
+
+  afterEach(() => {
+    subscribeSpy.mockRestore()
+  })
+
+  it('subscribes to user-profile on mount', () => {
+    renderHook(() => useProfile())
+    expect(subscribeSpy).toHaveBeenCalledWith('user-profile', expect.any(Function))
+  })
+
+  it('reloads profile when subscriber callback fires', () => {
+    const { result } = renderHook(() => useProfile())
+    expect(result.current.profile.name).toBe('')
+
+    const updatedProfile: Profile = {
+      name: 'Updated Name',
+      avatarDataUrl: 'data:image/png;base64,xyz',
+      birthday: '1985-12-25',
+    }
+    appStorage.setJSON(STORAGE_KEY, updatedProfile)
+
+    act(() => {
+      capturedCallback!(null)
+    })
+
+    expect(result.current.profile.name).toBe('Updated Name')
+    expect(result.current.profile.birthday).toBe('1985-12-25')
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useProfile())
+    expect(unsub).not.toHaveBeenCalled()
+    unmount()
+    expect(unsub).toHaveBeenCalled()
   })
 })

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { appStorage } from '../utils/appStorage'
 
 export interface Profile {
@@ -25,6 +25,14 @@ const loadProfile = (): Profile => {
 
 export const useProfile = () => {
   const [profile, setProfile] = useState<Profile>(loadProfile)
+
+  // Cross-tab sync: reload profile when another tab writes to storage
+  useEffect(() => {
+    const unsub = appStorage.subscribe(STORAGE_KEY, () => {
+      setProfile(loadProfile())
+    })
+    return unsub
+  }, [])
 
   const updateProfile = (updates: Partial<Profile>) => {
     setProfile(prev => {

--- a/src/pages/goal/hooks/useFinancialGoals.test.ts
+++ b/src/pages/goal/hooks/useFinancialGoals.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFinancialGoals } from './useFinancialGoals'
+import { appStorage } from '../../../utils/appStorage'
+import type { FinancialGoal } from '../../../types'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('useFinancialGoals hook', () => {
+  it('returns empty array when nothing stored', () => {
+    const { result } = renderHook(() => useFinancialGoals())
+    expect(result.current.goals).toEqual([])
+  })
+
+  it('loads goals from storage on mount', () => {
+    const goals: FinancialGoal[] = [
+      {
+        id: 1,
+        goalName: 'Retire Early',
+        goalCreatedIn: 2024,
+        goalEndYear: 2040,
+        currentAge: 35,
+        monthlyInvestment: 5000,
+        expectedReturn: 8,
+        currentSavings: 100000,
+      } as FinancialGoal,
+    ]
+    appStorage.setJSON('financialGoals', goals)
+    const { result } = renderHook(() => useFinancialGoals())
+    expect(result.current.goals).toHaveLength(1)
+    expect(result.current.goals[0].goalName).toBe('Retire Early')
+  })
+})
+
+describe('useFinancialGoals cross-tab sync', () => {
+  let subscribeSpy: ReturnType<typeof vi.spyOn>
+  let capturedCallback: ((value: string | null) => void) | undefined
+  let unsub: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    capturedCallback = undefined
+    unsub = vi.fn()
+    subscribeSpy = vi.spyOn(appStorage, 'subscribe').mockImplementation((key, cb) => {
+      if (key === 'financialGoals') capturedCallback = cb
+      return unsub
+    })
+  })
+
+  afterEach(() => {
+    subscribeSpy.mockRestore()
+  })
+
+  it('subscribes to financialGoals on mount', () => {
+    renderHook(() => useFinancialGoals())
+    expect(subscribeSpy).toHaveBeenCalledWith('financialGoals', expect.any(Function))
+  })
+
+  it('reloads goals when subscriber callback fires', () => {
+    const { result } = renderHook(() => useFinancialGoals())
+    expect(result.current.goals).toEqual([])
+
+    const updatedGoals: FinancialGoal[] = [
+      {
+        id: 2,
+        goalName: 'College Fund',
+        goalCreatedIn: 2025,
+        goalEndYear: 2043,
+        currentAge: 30,
+        monthlyInvestment: 2000,
+        expectedReturn: 7,
+        currentSavings: 50000,
+      } as FinancialGoal,
+    ]
+    appStorage.setJSON('financialGoals', updatedGoals)
+
+    act(() => {
+      capturedCallback!(null)
+    })
+
+    expect(result.current.goals).toHaveLength(1)
+    expect(result.current.goals[0].goalName).toBe('College Fund')
+  })
+
+  it('fromSyncRef prevents save effect from re-writing after sync', () => {
+    const setJSONSpy = vi.spyOn(appStorage, 'setJSON')
+    // We need to also spy on getString to return data when callback fires
+    const goals: FinancialGoal[] = [
+      {
+        id: 3,
+        goalName: 'Vacation',
+        goalCreatedIn: 2025,
+        goalEndYear: 2026,
+        currentAge: 35,
+        monthlyInvestment: 1000,
+        expectedReturn: 5,
+        currentSavings: 5000,
+      } as FinancialGoal,
+    ]
+    appStorage.setJSON('financialGoals', goals)
+
+    const { result } = renderHook(() => useFinancialGoals())
+    // Clear the spy calls from initial render/save
+    setJSONSpy.mockClear()
+
+    // Simulate cross-tab sync — the callback sets fromSyncRef = true
+    const newGoals: FinancialGoal[] = [
+      {
+        id: 4,
+        goalName: 'New Car',
+        goalCreatedIn: 2025,
+        goalEndYear: 2027,
+        currentAge: 35,
+        monthlyInvestment: 3000,
+        expectedReturn: 6,
+        currentSavings: 20000,
+      } as FinancialGoal,
+    ]
+    appStorage.setJSON('financialGoals', newGoals)
+
+    act(() => {
+      capturedCallback!(null)
+    })
+
+    // The state was updated
+    expect(result.current.goals[0].goalName).toBe('New Car')
+    // But the save effect should NOT have re-written (fromSyncRef guard)
+    // saveGoalsToStorage calls appStorage.setJSON('financialGoals', ...)
+    // The only setJSON call should be our manual one above, not from the save effect
+    const saveCalls = setJSONSpy.mock.calls.filter(c => c[0] === 'financialGoals')
+    // Only the manual call from our test setup, none from the save effect
+    expect(saveCalls).toHaveLength(1)
+
+    setJSONSpy.mockRestore()
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useFinancialGoals())
+    expect(unsub).not.toHaveBeenCalled()
+    unmount()
+    expect(unsub).toHaveBeenCalled()
+  })
+})

--- a/src/pages/goal/hooks/useFinancialGoals.ts
+++ b/src/pages/goal/hooks/useFinancialGoals.ts
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { FinancialGoal } from '../../../types'
 import { loadGoalsFromStorage, saveGoalsToStorage, migrateGoals } from '../utils/localStorageService'
+import { appStorage } from '../../../utils/appStorage'
 
 export const useFinancialGoals = () => {
   const [goals, setGoals] = useState<FinancialGoal[]>(() => {
@@ -13,8 +14,28 @@ export const useFinancialGoals = () => {
     }
   })
 
+  const fromSyncRef = useRef(false)
+
+  // Cross-tab sync: reload goals when another tab writes to storage
+  useEffect(() => {
+    const unsub = appStorage.subscribe('financialGoals', () => {
+      try {
+        const loaded = loadGoalsFromStorage()
+        fromSyncRef.current = true
+        setGoals(migrateGoals(loaded))
+      } catch {
+        /* load failed — don't set fromSyncRef so next local save proceeds normally */
+      }
+    })
+    return unsub
+  }, [])
+
   // Save goals to localStorage whenever they change
   useEffect(() => {
+    if (fromSyncRef.current) {
+      fromSyncRef.current = false
+      return
+    }
     saveGoalsToStorage(goals)
   }, [goals])
 

--- a/src/pages/goal/hooks/useGwGoals.test.ts
+++ b/src/pages/goal/hooks/useGwGoals.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
 import { useGwGoals } from './useGwGoals'
 import { appStorage } from '../../../utils/appStorage'
 import type { GwGoal } from '../../../types'
@@ -83,5 +83,93 @@ describe('GwGoal field migration logic', () => {
 
   it('handles empty array', () => {
     expect(migrateGwFields([])).toEqual([])
+  })
+})
+
+describe('useGwGoals cross-tab sync', () => {
+  let subscribeSpy: ReturnType<typeof vi.spyOn>
+  let capturedCallback: ((value: string | null) => void) | undefined
+  let unsub: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    capturedCallback = undefined
+    unsub = vi.fn()
+    subscribeSpy = vi.spyOn(appStorage, 'subscribe').mockImplementation((key, cb) => {
+      if (key === 'gw-goals') capturedCallback = cb
+      return unsub
+    })
+  })
+
+  afterEach(() => {
+    subscribeSpy.mockRestore()
+  })
+
+  it('subscribes to gw-goals on mount', () => {
+    renderHook(() => useGwGoals())
+    expect(subscribeSpy).toHaveBeenCalledWith('gw-goals', expect.any(Function))
+  })
+
+  it('reloads gw goals when subscriber callback fires', () => {
+    const { result } = renderHook(() => useGwGoals())
+    expect(result.current.gwGoals).toEqual([])
+
+    const updatedGoals: GwGoal[] = [
+      {
+        id: 10,
+        fiGoalId: 200,
+        label: 'Vacation Fund',
+        createdAt: '2025-06-01',
+        disburseAge: 45,
+        disburseAmount: 25000,
+        growthRate: 6,
+        currentSavings: 8000,
+      },
+    ]
+    appStorage.setJSON('gw-goals', updatedGoals)
+
+    act(() => {
+      capturedCallback!(null)
+    })
+
+    expect(result.current.gwGoals).toHaveLength(1)
+    expect(result.current.gwGoals[0].label).toBe('Vacation Fund')
+  })
+
+  it('fromSyncRef prevents save effect from re-writing after sync', () => {
+    const setJSONSpy = vi.spyOn(appStorage, 'setJSON')
+    const { result } = renderHook(() => useGwGoals())
+    setJSONSpy.mockClear()
+
+    const newGoals: GwGoal[] = [
+      {
+        id: 20,
+        fiGoalId: 300,
+        label: 'Education',
+        createdAt: '2025-07-01',
+        disburseAge: 50,
+        disburseAmount: 100000,
+        growthRate: 8,
+        currentSavings: 30000,
+      },
+    ]
+    appStorage.setJSON('gw-goals', newGoals)
+
+    act(() => {
+      capturedCallback!(null)
+    })
+
+    expect(result.current.gwGoals[0].label).toBe('Education')
+    const saveCalls = setJSONSpy.mock.calls.filter(c => c[0] === 'gw-goals')
+    expect(saveCalls).toHaveLength(1)
+
+    setJSONSpy.mockRestore()
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useGwGoals())
+    expect(unsub).not.toHaveBeenCalled()
+    unmount()
+    expect(unsub).toHaveBeenCalled()
   })
 })

--- a/src/pages/goal/hooks/useGwGoals.ts
+++ b/src/pages/goal/hooks/useGwGoals.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { GwGoal } from '../../../types'
 import { appStorage } from '../../../utils/appStorage'
 
@@ -44,7 +44,27 @@ const load = (): GwGoal[] => {
 export const useGwGoals = () => {
   const [gwGoals, setGwGoals] = useState<GwGoal[]>(load)
 
+  const fromSyncRef = useRef(false)
+
+  // Cross-tab sync: reload when another tab writes to storage
   useEffect(() => {
+    const unsub = appStorage.subscribe(STORAGE_KEY, () => {
+      try {
+        const loaded = load()
+        fromSyncRef.current = true
+        setGwGoals(loaded)
+      } catch {
+        /* load failed — don't set fromSyncRef so next local save proceeds normally */
+      }
+    })
+    return unsub
+  }, [])
+
+  useEffect(() => {
+    if (fromSyncRef.current) {
+      fromSyncRef.current = false
+      return
+    }
     appStorage.setJSON(STORAGE_KEY, gwGoals)
   }, [gwGoals])
 


### PR DESCRIPTION
## Cross-tab localStorage sync (#110)

Wires up `appStorage.subscribe()` in 4 hooks/providers missing cross-tab sync:
- **useFinancialGoals** — subscribes to `financialGoals` with fromSyncRef guard
- **useGwGoals** — subscribes to `gw-goals` with fromSyncRef guard  
- **useProfile** — subscribes to `user-profile`
- **SettingsContext** — subscribes to `darkMode`, `accentTheme`, `allowCsvImport`

The appStorage cross-tab infrastructure already existed (storage event listener + subscriber pattern). This wires up the consumers that were missing subscriptions.

19 new tests (2660 total). Code review by Emery — 1 finding fixed (fromSyncRef ordering to prevent dropped writes on load failure).

Fixes #110