### PR TITLE
test(e2e): Net Worth E2E suite (#57) — 33 tests

### DIFF
--- a/e2e/fixtures/net-worth.fixtures.ts
+++ b/e2e/fixtures/net-worth.fixtures.ts
@@ -1,0 +1,179 @@
+import { Page } from '@playwright/test'
+
+export const ACCOUNTS = [
+  {
+    id: 1,
+    name: '401(k)',
+    type: 'retirement',
+    owner: 'primary',
+    status: 'active',
+    goalType: 'fi',
+    nature: 'asset',
+    allocation: 'us-stock',
+    institution: 'Fidelity',
+    group: 'Retirement',
+  },
+  {
+    id: 2,
+    name: 'Roth IRA',
+    type: 'retirement',
+    owner: 'primary',
+    status: 'active',
+    goalType: 'fi',
+    nature: 'asset',
+    allocation: 'intl-stock',
+    institution: 'Vanguard',
+    group: 'Retirement',
+  },
+  {
+    id: 3,
+    name: 'Brokerage',
+    type: 'non-retirement',
+    owner: 'joint',
+    status: 'active',
+    goalType: 'fi',
+    nature: 'asset',
+    allocation: 'us-stock',
+    institution: 'Schwab',
+    group: 'Taxable',
+  },
+  {
+    id: 4,
+    name: 'High-Yield Savings',
+    type: 'liquid',
+    owner: 'joint',
+    status: 'active',
+    goalType: 'gw',
+    nature: 'asset',
+    allocation: 'cash',
+    institution: 'Marcus',
+    group: 'Cash',
+  },
+]
+
+export const INACTIVE_ACCOUNT = {
+  id: 5,
+  name: 'Old Savings',
+  type: 'liquid' as const,
+  owner: 'primary' as const,
+  status: 'inactive' as const,
+  goalType: 'gw' as const,
+  nature: 'asset' as const,
+  allocation: 'cash' as const,
+  institution: 'Wells Fargo',
+  group: '',
+}
+
+export const BALANCES = [
+  { id: 1, accountId: 1, month: '2025-05', balance: 180000 },
+  { id: 2, accountId: 2, month: '2025-05', balance: 65000 },
+  { id: 3, accountId: 3, month: '2025-05', balance: 95000 },
+  { id: 4, accountId: 4, month: '2025-05', balance: 42000 },
+  { id: 5, accountId: 1, month: '2025-04', balance: 175000 },
+  { id: 6, accountId: 2, month: '2025-04', balance: 63000 },
+  { id: 7, accountId: 3, month: '2025-04', balance: 92000 },
+  { id: 8, accountId: 4, month: '2025-04', balance: 41000 },
+]
+
+export function createLargeDataset(accountCount: number, monthCount: number) {
+  const accounts = Array.from({ length: accountCount }, (_, i) => ({
+    id: i + 1,
+    name: `Account ${i + 1}`,
+    type: 'non-retirement' as const,
+    owner: 'primary' as const,
+    status: 'active' as const,
+    goalType: 'fi' as const,
+    nature: 'asset' as const,
+    allocation: 'us-stock' as const,
+    institution: `Bank ${i + 1}`,
+    group: `Group ${Math.floor(i / 5) + 1}`,
+  }))
+
+  const balances: Array<{ id: number; accountId: number; month: string; balance: number }> = []
+  let id = 1
+  for (let m = 0; m < monthCount; m++) {
+    const year = 2025 - Math.floor(m / 12)
+    const month = 12 - (m % 12)
+    const monthStr = `${year}-${String(month).padStart(2, '0')}`
+    for (let a = 0; a < accountCount; a++) {
+      balances.push({ id: id++, accountId: a + 1, month: monthStr, balance: Math.round(Math.random() * 100000) })
+    }
+  }
+
+  return { accounts, balances }
+}
+
+export async function seedNetWorthData(
+  page: Page,
+  options: {
+    accounts?: typeof ACCOUNTS
+    balances?: typeof BALANCES
+    allowCsvImport?: boolean
+  } = {},
+) {
+  const { accounts = ACCOUNTS, balances = BALANCES, allowCsvImport } = options
+
+  await page.addInitScript(
+    ({ data }) => {
+      localStorage.clear()
+      localStorage.setItem('encryption-enabled', '0')
+      if (data.accounts) localStorage.setItem('data-accounts', JSON.stringify(data.accounts))
+      if (data.balances) localStorage.setItem('data-balances', JSON.stringify(data.balances))
+      if (data.allowCsvImport) localStorage.setItem('allowCsvImport', '1')
+    },
+    {
+      data: {
+        accounts,
+        balances,
+        allowCsvImport: allowCsvImport ?? true,
+      },
+    },
+  )
+}
+
+export async function seedEmptyState(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.clear()
+    localStorage.setItem('encryption-enabled', '0')
+  })
+}
+
+export async function seedCorruptedData(
+  page: Page,
+  variant: 'malformed-json' | 'corrupted-balances' | 'missing-keys',
+) {
+  await page.addInitScript(
+    ({ variant }) => {
+      localStorage.clear()
+      localStorage.setItem('encryption-enabled', '0')
+
+      if (variant === 'malformed-json') {
+        localStorage.setItem('data-accounts', '{not valid json[')
+        localStorage.setItem('data-balances', '{also broken')
+      } else if (variant === 'corrupted-balances') {
+        localStorage.setItem(
+          'data-accounts',
+          JSON.stringify([
+            {
+              id: 1,
+              name: 'Test Account',
+              type: 'retirement',
+              owner: 'primary',
+              status: 'active',
+              goalType: 'fi',
+              nature: 'asset',
+              allocation: 'us-stock',
+            },
+          ]),
+        )
+        localStorage.setItem('data-balances', JSON.stringify([{ id: 1, accountId: 999, month: '2025-01', balance: 'not-a-number' }]))
+      } else if (variant === 'missing-keys') {
+        localStorage.setItem(
+          'data-accounts',
+          JSON.stringify([{ id: 1, name: 'Partial Account' }]),
+        )
+      }
+    },
+    { variant },
+  )
+}

--- a/e2e/net-worth.spec.ts
+++ b/e2e/net-worth.spec.ts
@@ -1,0 +1,397 @@
+import { test, expect } from '@playwright/test'
+import { NetWorthPage } from './pages/net-worth.page'
+import {
+  ACCOUNTS,
+  BALANCES,
+  INACTIVE_ACCOUNT,
+  seedNetWorthData,
+  seedEmptyState,
+  seedCorruptedData,
+  createLargeDataset,
+} from './fixtures/net-worth.fixtures'
+
+test.describe('Net Worth — Empty State', () => {
+  test('displays empty state message when no accounts exist', async ({ page }) => {
+    await seedEmptyState(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await expect(nw.emptyTitle).toHaveText('No accounts yet')
+  })
+
+  test('displays Add Account button in empty state', async ({ page }) => {
+    await seedEmptyState(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await expect(nw.emptyAddBtn).toBeVisible()
+  })
+})
+
+test.describe('Net Worth — Account Management', () => {
+  test('opens AccountsModal when clicking View Accounts button', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    await expect(nw.modal).toBeVisible()
+  })
+
+  test('displays all seeded accounts in the modal', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    for (const account of ACCOUNTS) {
+      await expect(nw.getAccountName(account.name)).toBeVisible()
+    }
+  })
+
+  test('creates a new account via the form', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    await nw.addAccount('Test Checking', 'Chase')
+    await expect(nw.getAccountName('Test Checking')).toBeVisible()
+  })
+
+  test('edits an existing account name', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    await nw.getEditBtn(0).click()
+    await nw.accountNameInput.waitFor({ state: 'visible' })
+    await nw.accountNameInput.clear()
+    await nw.accountNameInput.fill('Updated 401(k)')
+    await nw.formSaveBtn.click()
+    await expect(nw.getAccountName('Updated 401(k)')).toBeVisible()
+  })
+
+  test('deletes an account from the modal', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    await expect(nw.getAccountName('High-Yield Savings')).toBeVisible()
+    await nw.getDeleteBtn(3).click()
+    await expect(nw.getAccountName('High-Yield Savings')).not.toBeVisible()
+  })
+})
+
+test.describe('Net Worth — Balance Entry', () => {
+  test('shows inline entry row when Add Entry is clicked', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    await nw.addEntryBtn.click()
+    await expect(nw.inlineMonthInput).toBeVisible()
+  })
+
+  test('saves a new balance entry via inline form', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    await nw.addEntryBtn.click()
+    await nw.getInlineBalanceInput(0).fill('200000')
+    await nw.inlineSaveBtn.click()
+    await expect(nw.inlineMonthInput).not.toBeVisible()
+    // Verify saved value appears in spreadsheet
+    await expect(nw.spreadsheetWrap).toContainText('200,000')
+  })
+
+  test('copies balances from last month when Copy Last Month is clicked', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    await nw.copyLastMonthBtn.click()
+    await expect(nw.inlineMonthInput).toBeVisible()
+    // Verify inputs are pre-filled (non-empty)
+    const firstInput = nw.getInlineBalanceInput(0)
+    await expect(firstInput).not.toHaveValue('')
+  })
+
+  test('deletes a month row from the spreadsheet', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    const monthLabels = page.locator('.data-spreadsheet-month-label')
+    const initialCount = await monthLabels.count()
+    // Delete button is hidden until row header is hovered
+    const firstRowHeader = page.locator('.data-spreadsheet-row-header').first()
+    await firstRowHeader.hover()
+    await nw.deleteRowBtns.first().click()
+    const confirmBtn = page.locator('button', { hasText: 'Delete' })
+    const hasConfirm = await confirmBtn.isVisible({ timeout: 1000 }).catch((e) => {
+      if (e.message?.includes('Timeout')) return false
+      throw e
+    })
+    if (hasConfirm) {
+      await confirmBtn.click()
+    }
+    await expect(monthLabels).toHaveCount(initialCount - 1)
+  })
+})
+
+test.describe('Net Worth — Data View Toggle', () => {
+  test('switches to Charts view when Charts tab is clicked', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.chartsTab.click()
+    await expect(nw.chartsTab).toHaveAttribute('aria-selected', 'true')
+    await expect(nw.chartsTypePicker).toBeVisible()
+  })
+
+  test('switches to Spreadsheet view when Spreadsheet tab is clicked', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    await expect(nw.spreadsheetTab).toHaveAttribute('aria-selected', 'true')
+    await expect(nw.spreadsheetWrap).toBeVisible()
+  })
+
+  test('shows inactive accounts when Show inactive checkbox is checked', async ({ page }) => {
+    await seedNetWorthData(page, { accounts: [...ACCOUNTS, INACTIVE_ACCOUNT] })
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    // Inactive account should be hidden initially
+    await expect(page.locator('.data-spreadsheet-account-name', { hasText: 'Old Savings' })).not.toBeVisible()
+    await nw.showInactiveLabel.click()
+    await expect(page.locator('.data-spreadsheet-account-name', { hasText: 'Old Savings' })).toBeVisible()
+  })
+})
+
+test.describe('Net Worth — CSV Import/Export/Reset', () => {
+  test('shows import button when CSV import is enabled', async ({ page }) => {
+    await seedNetWorthData(page, { allowCsvImport: true })
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await expect(nw.importCsvBtn).toBeVisible()
+  })
+
+  test('shows export button when accounts and balances exist', async ({ page }) => {
+    await seedNetWorthData(page, { allowCsvImport: true })
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await expect(nw.exportCsvBtn).toBeVisible()
+  })
+
+  test('shows reset button when CSV import is enabled and data exists', async ({ page }) => {
+    await seedNetWorthData(page, { allowCsvImport: true })
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await expect(nw.resetBtn).toBeVisible()
+  })
+})
+
+test.describe('Net Worth — Tab Navigation', () => {
+  test('navigates to Allocation tab', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.getTabLink('Allocation').click()
+    await expect(page).toHaveURL(/\/net-worth\/allocation/)
+  })
+
+  test('navigates to Growth tab', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.getTabLink('Growth').click()
+    await expect(page).toHaveURL(/\/net-worth\/growth/)
+  })
+})
+
+test.describe('Net Worth — Home Card Month Arrows', () => {
+  test('navigates between months using arrow buttons on Home card', async ({ page }) => {
+    await seedNetWorthData(page)
+    await page.goto('/finance-tracking/')
+    await page.waitForLoadState('domcontentloaded')
+    const prevBtn = page.getByLabel('Previous month')
+    const nwDate = page.locator('.nw-date')
+    const initialDate = await nwDate.textContent()
+    await prevBtn.click()
+    const newDate = await nwDate.textContent()
+    expect(newDate).not.toEqual(initialDate)
+  })
+})
+
+test.describe('Net Worth — Edge Cases', () => {
+  test('handles zero balance entries without errors', async ({ page }) => {
+    const zeroBalances = BALANCES.map(b => ({ ...b, balance: 0 }))
+    await seedNetWorthData(page, { balances: zeroBalances })
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    await expect(nw.spreadsheetWrap).toBeVisible()
+  })
+
+  test('handles malformed CSV file gracefully on import', async ({ page }) => {
+    await seedNetWorthData(page, { allowCsvImport: true })
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.csvFileInput.setInputFiles({
+      name: 'bad.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from('not,a,valid,csv\n,,,\ngarbage\n'),
+    })
+    // App should not crash — page remains functional
+    await expect(page.locator('body')).not.toContainText('Unhandled Runtime Error')
+    await expect(nw.viewAccountsBtn).toBeVisible()
+  })
+
+  test('renders large dataset without crashing', async ({ page }) => {
+    const { accounts, balances } = createLargeDataset(20, 24)
+    await seedNetWorthData(page, { accounts, balances })
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    await expect(nw.spreadsheetWrap).toBeVisible()
+  })
+})
+
+test.describe('Net Worth — Corruption Resilience', () => {
+  test('does not crash with malformed JSON in localStorage', async ({ page }) => {
+    await seedCorruptedData(page, 'malformed-json')
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await expect(page.locator('body')).toBeVisible()
+    const content = await page.content()
+    expect(content).not.toContain('Unhandled Runtime Error')
+    // No data artifacts
+    await expect(page.locator('body')).not.toContainText('NaN')
+    await expect(page.locator('body')).not.toContainText('Infinity')
+  })
+
+  test('does not crash with corrupted balance entries', async ({ page }) => {
+    await seedCorruptedData(page, 'corrupted-balances')
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await expect(page.locator('body')).toBeVisible()
+    const content = await page.content()
+    expect(content).not.toContain('Unhandled Runtime Error')
+    // Account should still render even if balances are corrupted
+    await expect(nw.viewAccountsBtn).toBeVisible()
+    // No NaN or Infinity artifacts
+    await expect(page.locator('body')).not.toContainText('NaN')
+    await expect(page.locator('body')).not.toContainText('Infinity')
+  })
+
+  test('does not crash with accounts missing required keys', async ({ page }) => {
+    await seedCorruptedData(page, 'missing-keys')
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await expect(page.locator('body')).toBeVisible()
+    const content = await page.content()
+    expect(content).not.toContain('Unhandled Runtime Error')
+    // No NaN or undefined text artifacts
+    await expect(page.locator('body')).not.toContainText('NaN')
+    await expect(page.locator('body')).not.toContainText('undefined')
+  })
+})
+
+test.describe('Net Worth — Keyboard Navigation', () => {
+  test('closes AccountsModal with Escape key', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    await expect(nw.modal).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(nw.modal).not.toBeVisible()
+  })
+
+  test('submits account form with Enter key', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    await nw.modalAddBtn.click()
+    await nw.accountNameInput.waitFor({ state: 'visible' })
+    await nw.accountNameInput.fill('Keyboard Account')
+    await page.keyboard.press('Enter')
+    await expect(nw.getAccountName('Keyboard Account')).toBeVisible()
+  })
+
+  test('toggles chart type buttons with keyboard', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.chartsTab.click()
+    const secondBtn = nw.getChartTypeBtn(1)
+    await secondBtn.focus()
+    await page.keyboard.press('Enter')
+    await expect(secondBtn).toHaveAttribute('aria-pressed', 'true')
+  })
+})
+
+test.describe('Net Worth — Accessibility', () => {
+  test('chart type toggle buttons have aria-pressed attribute', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.chartsTab.click()
+    const firstBtn = nw.getChartTypeBtn(0)
+    await expect(firstBtn).toHaveAttribute('aria-pressed', 'true')
+    const secondBtn = nw.getChartTypeBtn(1)
+    await expect(secondBtn).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  test('account form fields have associated labels', async ({ page }) => {
+    await seedNetWorthData(page)
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    await nw.modalAddBtn.click()
+    await nw.accountForm.waitFor({ state: 'visible' })
+    // Verify form fields have labels
+    const labels = nw.accountForm.locator('label')
+    const labelCount = await labels.count()
+    expect(labelCount).toBeGreaterThan(0)
+  })
+})
+
+test.describe('Net Worth — Performance', () => {
+  test('renders large dataset (50 accounts, 36 months) within 5 seconds', async ({ page }) => {
+    const { accounts, balances } = createLargeDataset(50, 36)
+    await seedNetWorthData(page, { accounts, balances })
+    const nw = new NetWorthPage(page)
+    const start = Date.now()
+    await nw.goto()
+    await nw.spreadsheetTab.click()
+    await expect(nw.spreadsheetWrap).toBeVisible()
+    const elapsed = Date.now() - start
+    expect(elapsed).toBeLessThan(5000)
+  })
+})
+
+test.describe('Net Worth — Security', () => {
+  test('XSS in account name is rendered as text, not executed', async ({ page }) => {
+    let alertFired = false
+    page.on('dialog', async (dialog) => {
+      alertFired = true
+      await dialog.dismiss()
+    })
+
+    const xssAccounts = [
+      {
+        ...ACCOUNTS[0],
+        id: 99,
+        name: '<script>alert("xss")</script>',
+      },
+    ]
+    await seedNetWorthData(page, { accounts: xssAccounts, balances: [] })
+    const nw = new NetWorthPage(page)
+    await nw.goto()
+    await nw.openAccountsModal()
+    const nameCell = nw.modal.locator('.data-account-name')
+    await expect(nameCell).toContainText('<script>')
+    expect(alertFired).toBe(false)
+  })
+})

--- a/e2e/pages/net-worth.page.ts
+++ b/e2e/pages/net-worth.page.ts
@@ -1,0 +1,164 @@
+import { Page, Locator } from '@playwright/test'
+
+export class NetWorthPage {
+  readonly page: Page
+
+  // Empty state
+  readonly emptyContainer: Locator
+  readonly emptyTitle: Locator
+  readonly emptyAddBtn: Locator
+
+  // Header actions
+  readonly viewAccountsBtn: Locator
+  readonly addEntryBtn: Locator
+  readonly copyLastMonthBtn: Locator
+  readonly importCsvBtn: Locator
+  readonly exportCsvBtn: Locator
+  readonly resetBtn: Locator
+  readonly csvFileInput: Locator
+
+  // View tabs
+  readonly viewTabList: Locator
+  readonly chartsTab: Locator
+  readonly spreadsheetTab: Locator
+
+  // Tab navigation (Accounts / Allocation / Growth)
+  readonly tabBar: Locator
+
+  // AccountsModal
+  readonly modal: Locator
+  readonly modalCloseBtn: Locator
+  readonly modalAddBtn: Locator
+
+  // AccountForm
+  readonly accountForm: Locator
+  readonly accountNameInput: Locator
+  readonly institutionInput: Locator
+  readonly formSaveBtn: Locator
+  readonly formCancelBtn: Locator
+
+  // Spreadsheet
+  readonly spreadsheetWrap: Locator
+  readonly spreadsheet: Locator
+  readonly inlineMonthInput: Locator
+  readonly inlineSaveBtn: Locator
+  readonly inlineCancelBtn: Locator
+  readonly deleteRowBtns: Locator
+
+  // Charts
+  readonly chartsTypePicker: Locator
+
+  // Show inactive
+  readonly showInactiveLabel: Locator
+
+  constructor(page: Page) {
+    this.page = page
+
+    // Empty state
+    this.emptyContainer = page.locator('.data-empty').first()
+    this.emptyTitle = page.locator('.data-empty-title').first()
+    this.emptyAddBtn = page.locator('.data-empty .data-add-btn')
+
+    // Header actions
+    this.viewAccountsBtn = page.locator('button.data-view-accounts-btn')
+    this.addEntryBtn = page.locator('button.data-add-entry-btn').first()
+    this.copyLastMonthBtn = page.getByLabel('Copy balances from last month')
+    this.importCsvBtn = page.locator('button.data-import-csv-btn').first()
+    this.exportCsvBtn = page.locator('button.data-export-csv-btn')
+    this.resetBtn = page.locator('button.data-reset-btn')
+    this.csvFileInput = page.locator('input[aria-label="Import CSV file"]')
+
+    // View tabs
+    this.viewTabList = page.locator('[role="tablist"][aria-label="Data view"]')
+    this.chartsTab = page.getByRole('tab', { name: 'Charts' })
+    this.spreadsheetTab = page.getByRole('tab', { name: 'Spreadsheet' })
+
+    // Tab navigation
+    this.tabBar = page.locator('nav[aria-label="Net Worth sections"]')
+
+    // AccountsModal
+    this.modal = page.locator('div[role="dialog"][aria-modal="true"]')
+    this.modalCloseBtn = page.locator('button.data-modal-close')
+    this.modalAddBtn = this.modal.locator('button.data-add-btn')
+
+    // AccountForm
+    this.accountForm = page.locator('form.data-form')
+    this.accountNameInput = page.locator('input[placeholder="e.g. Chase Checking"]')
+    this.institutionInput = page.locator('input[placeholder="e.g. Chase"]')
+    this.formSaveBtn = page.locator('button.data-form-save')
+    this.formCancelBtn = page.locator('button.data-form-cancel')
+
+    // Spreadsheet
+    this.spreadsheetWrap = page.locator('.data-spreadsheet-wrap')
+    this.spreadsheet = page.locator('table.data-spreadsheet')
+    this.inlineMonthInput = page.locator('input.data-inline-month-input')
+    this.inlineSaveBtn = page.locator('button.data-inline-save')
+    this.inlineCancelBtn = page.locator('button.data-inline-cancel')
+    this.deleteRowBtns = page.locator('button.data-delete-row-btn')
+
+    // Charts
+    this.chartsTypePicker = page.locator('.data-charts-type-picker')
+
+    // Show inactive
+    this.showInactiveLabel = page.locator('label.data-filter-toggle')
+  }
+
+  async goto() {
+    await this.page.goto('/finance-tracking/#/net-worth')
+    await this.page.waitForLoadState('domcontentloaded')
+  }
+
+  async gotoAllocation() {
+    await this.page.goto('/finance-tracking/#/net-worth/allocation')
+    await this.page.waitForLoadState('domcontentloaded')
+  }
+
+  async gotoGrowth() {
+    await this.page.goto('/finance-tracking/#/net-worth/growth')
+    await this.page.waitForLoadState('domcontentloaded')
+  }
+
+  async openAccountsModal() {
+    await this.viewAccountsBtn.click()
+    await this.modal.waitFor({ state: 'visible' })
+  }
+
+  async closeAccountsModal() {
+    await this.modalCloseBtn.first().click()
+    await this.modal.waitFor({ state: 'hidden' })
+  }
+
+  async addAccount(name: string, institution?: string) {
+    await this.modalAddBtn.click()
+    await this.accountNameInput.waitFor({ state: 'visible' })
+    await this.accountNameInput.fill(name)
+    if (institution) {
+      await this.institutionInput.fill(institution)
+    }
+    await this.formSaveBtn.click()
+  }
+
+  getAccountName(name: string): Locator {
+    return this.modal.locator('.data-account-name', { hasText: name })
+  }
+
+  getEditBtn(index: number): Locator {
+    return this.modal.locator('button.data-action-btn').nth(index)
+  }
+
+  getDeleteBtn(index: number): Locator {
+    return this.modal.locator('button.data-action-btn--delete').nth(index)
+  }
+
+  getInlineBalanceInput(index: number): Locator {
+    return this.page.locator('input.data-inline-balance-input').nth(index)
+  }
+
+  getChartTypeBtn(index: number): Locator {
+    return this.chartsTypePicker.locator('button.data-filter-btn').nth(index)
+  }
+
+  getTabLink(name: string): Locator {
+    return this.tabBar.locator('.nw-tab', { hasText: name })
+  }
+}


### PR DESCRIPTION
## Summary
33 E2E tests for the Net Worth page covering the full feature surface.

### Test Coverage
| Section | Tests | Coverage |
|---------|-------|----------|
| Empty State | 2 | No-accounts message, Add Account button |
| Account Management | 5 | Open modal, display all, create, edit, delete |
| Balance Entry | 4 | Inline row, save + verify value, copy last month, delete month |
| Data View Toggle | 3 | Charts, Spreadsheet, Show inactive |
| CSV Import/Export/Reset | 3 | Import/export/reset button visibility |
| Tab Navigation | 2 | Allocation, Growth tabs |
| Home Card Month Arrows | 1 | Previous month navigation |
| Edge Cases | 3 | Zero balances, malformed CSV import, large dataset |
| Corruption Resilience | 3 | Malformed JSON, corrupted balances, missing keys |
| Keyboard Navigation | 3 | Escape closes modal, Enter submits, chart toggle |
| Accessibility | 2 | aria-pressed on chart toggles, form labels |
| Performance | 1 | 50 accounts × 36 months renders <5s |
| Security | 1 | XSS in account name neutralized |

### Files
- `e2e/net-worth.spec.ts` — 33 test cases
- `e2e/pages/net-worth.page.ts` — Page object
- `e2e/fixtures/net-worth.fixtures.ts` — Seed data factories

### Review Findings (already fixed)
- Alex: XSS dialog listener race condition, delete error masking — ✅ Fixed
- Casey: Same + weak save assertion, CSV skip, corruption assertions — ✅ Fixed

Fixes #57