### PR TITLE
test(e2e): encryption lifecycle + cross-tab + envelope verification (#127)

### DIFF
--- a/e2e/encryption.spec.ts
+++ b/e2e/encryption.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 import { SecurityPage } from './pages/security.page'
 import {
   SENSITIVE_KEYS,
+  type SensitiveKey,
   assertAllKeysAreEnvelopes,
   assertAllKeysMatchPlaintextSnapshot,
   dispatchRemoteLock,
@@ -146,7 +147,7 @@ test.describe('Encryption Lifecycle, Cross-Tab & Envelope Verification', () => {
       // writes the cross-tab lock signal: tab B's appStorage receives the
       // native `storage` event, dispatches `encryption-remote-lock`, and
       // EncryptionContext clears the in-memory key.
-      await seedEmptyEncryptionState(page)
+      await seedEmptyEncryptionState(context)
       const securityA = new SecurityPage(page)
       await securityA.open()
       await securityA.enable(PASSPHRASE)
@@ -177,7 +178,7 @@ test.describe('Encryption Lifecycle, Cross-Tab & Envelope Verification', () => {
       // (was #60 test 30) — enable propagates across tabs natively. No
       // synthetic event dispatch — we let the browser's native `storage`
       // event fire when tab A writes `encryption-enabled=1`.
-      await seedEmptyEncryptionState(page)
+      await seedEmptyEncryptionState(context)
 
       // Open tab A (the default `page`) and tab B in parallel, both on the
       // app root. Both start in the disabled, unlocked state.
@@ -246,7 +247,7 @@ test.describe('Encryption Lifecycle, Cross-Tab & Envelope Verification', () => {
       // app may normalize seeded values during boot (e.g. budget-config
       // gains default category groups), so the roundtrip must compare
       // against the POST-NAVIGATION plaintext, not the raw seed payload.
-      const snapshot: Record<string, unknown> = {}
+      const snapshot = {} as Record<SensitiveKey, unknown>
       for (const key of SENSITIVE_KEYS) {
         snapshot[key] = await readEnvelope(page, key)
       }
@@ -259,7 +260,7 @@ test.describe('Encryption Lifecycle, Cross-Tab & Envelope Verification', () => {
       // Every sensitive key now holds plaintext that matches the captured
       // snapshot exactly. Not toMatchObject, not toBeDefined — structural
       // equality with the original plaintext value.
-      await assertAllKeysMatchPlaintextSnapshot(page, snapshot as Parameters<typeof assertAllKeysMatchPlaintextSnapshot>[1])
+      await assertAllKeysMatchPlaintextSnapshot(page, snapshot)
 
       // Encryption lifecycle keys are gone.
       expect(await page.evaluate(() => localStorage.getItem('encryption-enabled'))).not.toBe('1')

--- a/e2e/encryption.spec.ts
+++ b/e2e/encryption.spec.ts
@@ -1,0 +1,270 @@
+import { test, expect } from '@playwright/test'
+import { SecurityPage } from './pages/security.page'
+import {
+  SENSITIVE_KEYS,
+  assertAllKeysAreEnvelopes,
+  assertAllKeysMatchPlaintextSnapshot,
+  dispatchRemoteLock,
+  isEnvelope,
+  readEnvelope,
+  seedAllSensitiveKeys,
+  seedEmptyEncryptionState,
+} from './fixtures/encryption.fixtures'
+
+const PASSPHRASE = 'TestPass123'
+const NEW_PASSPHRASE = 'NewTestPass456'
+
+test.describe('Encryption Lifecycle, Cross-Tab & Envelope Verification', () => {
+  test.describe('Security Pane Lifecycle', () => {
+    test('shows disabled state initially', async ({ page }) => {
+      // (was #60 test 15) — fresh app, no encryption set up.
+      await seedEmptyEncryptionState(page)
+      const security = new SecurityPage(page)
+      await security.open()
+
+      await expect(security.status).toHaveText(/Encryption disabled/)
+      await expect(security.enableTriggerBtn).toBeVisible()
+      await expect(security.changeTriggerBtn).toHaveCount(0)
+      await expect(security.disableTriggerBtn).toHaveCount(0)
+      expect(await page.evaluate(() => localStorage.getItem('encryption-enabled'))).not.toBe('1')
+    })
+
+    test('enabling encryption with a passphrase shows success', async ({ page }) => {
+      // (was #60 test 16) — happy-path enable.
+      await seedEmptyEncryptionState(page)
+      const security = new SecurityPage(page)
+      await security.open()
+
+      await security.enable(PASSPHRASE)
+
+      await expect(security.status).toHaveText(/Encryption enabled/)
+      await expect(security.changeTriggerBtn).toBeVisible()
+      await expect(security.disableTriggerBtn).toBeVisible()
+      expect(await page.evaluate(() => localStorage.getItem('encryption-enabled'))).toBe('1')
+    })
+
+    test('enabling encryption with mismatched confirm shows error', async ({ page }) => {
+      // (was #60 test 17) — typo guard.
+      await seedEmptyEncryptionState(page)
+      const security = new SecurityPage(page)
+      await security.open()
+
+      await security.enableTriggerBtn.click()
+      await expect(security.setupForm).toBeVisible()
+      await security.setupPassInput.fill(PASSPHRASE)
+      await security.setupConfirmInput.fill('DifferentPass')
+
+      // The mismatch error is visible immediately on confirm change.
+      await expect(security.setupConfirmError).toHaveText(/Passphrases don't match/)
+      // Submit is disabled while mismatched — clicking does nothing.
+      await expect(security.setupSubmitBtn).toBeDisabled()
+
+      // Form remains open; state did not change.
+      await expect(security.setupForm).toBeVisible()
+      expect(await page.evaluate(() => localStorage.getItem('encryption-enabled'))).not.toBe('1')
+      expect(await page.evaluate(() => localStorage.getItem('encryption-salt'))).toBeNull()
+    })
+
+    test('changing passphrase requires current passphrase and rotates the key', async ({ page }) => {
+      // (was #60 test 18) — change passphrase + bonus key-rotation roundtrip.
+      await seedEmptyEncryptionState(page)
+      const security = new SecurityPage(page)
+      await security.open()
+      await security.enable(PASSPHRASE)
+
+      await security.changePassphrase(PASSPHRASE, NEW_PASSPHRASE)
+      await expect(security.successFlash).toHaveText(/Passphrase updated/)
+
+      // Bonus assertion: the KEY actually rotated, not just the verifier.
+      // Dispatch `encryption-remote-lock` in the current tab — the
+      // EncryptionContext listener clears the in-memory key without
+      // reloading (which would re-run addInitScript and wipe state).
+      await page.evaluate(() => window.dispatchEvent(new CustomEvent('encryption-remote-lock')))
+
+      const passInput = page.getByLabel(/passphrase/i).first()
+      const unlockBtn = page.getByRole('button', { name: /^Unlock$|^Unlocking…$/ })
+
+      await expect(page.getByRole('heading', { name: /unlock/i })).toBeVisible()
+
+      // Old passphrase must fail.
+      await passInput.fill(PASSPHRASE)
+      await unlockBtn.click()
+      await expect(page.getByRole('alert').filter({ hasText: /Wrong passphrase/ })).toBeVisible()
+
+      // New passphrase must succeed — UnlockScreen disappears.
+      await passInput.fill(NEW_PASSPHRASE)
+      await unlockBtn.click()
+      await expect(page.getByRole('heading', { name: /unlock/i })).toBeHidden()
+    })
+
+    test('disabling encryption requires current passphrase', async ({ page }) => {
+      // (was #60 test 19) — happy-path disable.
+      await seedEmptyEncryptionState(page)
+      const security = new SecurityPage(page)
+      await security.open()
+      await security.enable(PASSPHRASE)
+
+      await security.disable(PASSPHRASE)
+
+      await expect(security.status).toHaveText(/Encryption disabled/)
+      await expect(security.enableTriggerBtn).toBeVisible()
+      expect(await page.evaluate(() => localStorage.getItem('encryption-enabled'))).not.toBe('1')
+      expect(await page.evaluate(() => localStorage.getItem('encryption-salt'))).toBeNull()
+      expect(await page.evaluate(() => localStorage.getItem('encryption-verify'))).toBeNull()
+    })
+
+    test('incorrect passphrase on disable shows error and preserves envelopes', async ({ page }) => {
+      // (was #60 test 20) — wrong passphrase must not leak data.
+      await seedAllSensitiveKeys(page)
+      const security = new SecurityPage(page)
+      await security.open()
+      await security.enable(PASSPHRASE)
+
+      // Sanity: confirm we are in the encrypted-at-rest state before the attack.
+      await assertAllKeysAreEnvelopes(page)
+
+      await security.disableTriggerBtn.click()
+      await expect(security.disableForm).toBeVisible()
+      await security.disablePassInput.fill('WrongPassphrase')
+      await security.disableSubmitBtn.click()
+
+      await expect(security.disableError).toHaveText(/Incorrect passphrase/)
+      // Encryption remains enabled; envelopes intact across every sensitive key.
+      await expect(security.status).toHaveText(/Encryption enabled/)
+      expect(await page.evaluate(() => localStorage.getItem('encryption-enabled'))).toBe('1')
+      await assertAllKeysAreEnvelopes(page)
+    })
+  })
+
+  test.describe('Cross-Tab', () => {
+    test('lock signal from tab A propagates UnlockScreen to tab B via encryption-remote-lock', async ({
+      context,
+      page,
+    }) => {
+      // (was #60 test 29) — stale-tab attack prevention.
+      // Tab A enables encryption, then tab B opens and unlocks. Then tab A
+      // writes the cross-tab lock signal: tab B's appStorage receives the
+      // native `storage` event, dispatches `encryption-remote-lock`, and
+      // EncryptionContext clears the in-memory key.
+      await seedEmptyEncryptionState(page)
+      const securityA = new SecurityPage(page)
+      await securityA.open()
+      await securityA.enable(PASSPHRASE)
+
+      const tabB = await context.newPage()
+      await tabB.goto('/finance-tracking/')
+      await tabB.waitForLoadState('domcontentloaded')
+
+      // Tab B mounts with encryption-enabled=1 and no in-memory key → locked.
+      await expect(tabB.getByRole('heading', { name: /unlock/i })).toBeVisible()
+
+      // Unlock tab B by entering the passphrase.
+      await tabB.getByLabel(/passphrase/i).first().fill(PASSPHRASE)
+      await tabB.getByRole('button', { name: /^Unlock$/ }).click()
+      await expect(tabB.getByRole('heading', { name: /unlock/i })).toBeHidden()
+
+      // Tab A dispatches the cross-tab lock signal (the real mechanism that
+      // appStorage.lock() uses). The native storage event fires in tab B
+      // only — tab A does not receive its own write.
+      await dispatchRemoteLock(page)
+
+      // Tab B locks: UnlockScreen reappears.
+      await expect(tabB.getByRole('heading', { name: /unlock/i })).toBeVisible()
+      await expect(tabB.getByLabel(/passphrase/i).first()).toBeVisible()
+    })
+
+    test('enable in tab A triggers UnlockScreen in tab B via native storage event', async ({ context, page }) => {
+      // (was #60 test 30) — enable propagates across tabs natively. No
+      // synthetic event dispatch — we let the browser's native `storage`
+      // event fire when tab A writes `encryption-enabled=1`.
+      await seedEmptyEncryptionState(page)
+
+      // Open tab A (the default `page`) and tab B in parallel, both on the
+      // app root. Both start in the disabled, unlocked state.
+      await page.goto('/finance-tracking/')
+      await page.waitForLoadState('domcontentloaded')
+
+      const tabB = await context.newPage()
+      await tabB.goto('/finance-tracking/')
+      await tabB.waitForLoadState('domcontentloaded')
+
+      // Sanity: tab B is unlocked (no Unlock heading visible).
+      await expect(tabB.getByRole('heading', { name: /unlock/i })).toHaveCount(0)
+
+      // In tab A, drive the real enable flow.
+      const securityA = new SecurityPage(page)
+      await securityA.settingsButton.click()
+      await securityA.settingsModal.waitFor({ state: 'visible' })
+      await securityA.securityNavBtn.click()
+      await securityA.enable(PASSPHRASE)
+
+      // Tab B detects the native storage event for `encryption-enabled=1`
+      // (handled by the new listener in EncryptionContext) and flips into
+      // the locked state — UnlockScreen appears without any reload.
+      await expect(tabB.getByRole('heading', { name: /unlock/i })).toBeVisible()
+      await expect(tabB.getByLabel(/passphrase/i).first()).toBeVisible()
+
+      // Both tabs show consistent encryption state.
+      expect(await page.evaluate(() => localStorage.getItem('encryption-enabled'))).toBe('1')
+      expect(await tabB.evaluate(() => localStorage.getItem('encryption-enabled'))).toBe('1')
+    })
+  })
+
+  test.describe('Envelope Verification', () => {
+    test('enabling encryption converts all 13 sensitive keys to envelope format', async ({ page }) => {
+      // (was #60 test 36) — every sensitive key must hold { v, iv, ct }
+      // after enable. One assertion per key with the key name in the
+      // failure message.
+      await seedAllSensitiveKeys(page)
+
+      const security = new SecurityPage(page)
+      await security.open()
+
+      // Sanity (post-navigation): every key is present as plaintext, not an
+      // envelope, before enabling encryption. The app may have normalized
+      // some seeded values during boot, but no key should look encrypted yet.
+      for (const key of SENSITIVE_KEYS) {
+        const value = await readEnvelope(page, key)
+        expect(value, `${key} should be present before enable`).not.toBeNull()
+        expect(isEnvelope(value), `${key} should NOT look like an envelope before enable`).toBe(false)
+      }
+
+      await security.enable(PASSPHRASE)
+
+      // Every sensitive key now holds an EncryptedEnvelope.
+      await assertAllKeysAreEnvelopes(page)
+    })
+
+    test('disabling encryption converts all 13 sensitive keys back to plaintext', async ({ page }) => {
+      // (was #60 test 37) — roundtrip: plaintext-before === plaintext-after.
+      await seedAllSensitiveKeys(page)
+
+      const security = new SecurityPage(page)
+      await security.open()
+
+      // Snapshot the actual plaintext in localStorage at this moment. The
+      // app may normalize seeded values during boot (e.g. budget-config
+      // gains default category groups), so the roundtrip must compare
+      // against the POST-NAVIGATION plaintext, not the raw seed payload.
+      const snapshot: Record<string, unknown> = {}
+      for (const key of SENSITIVE_KEYS) {
+        snapshot[key] = await readEnvelope(page, key)
+      }
+
+      await security.enable(PASSPHRASE)
+      await assertAllKeysAreEnvelopes(page)
+
+      await security.disable(PASSPHRASE)
+
+      // Every sensitive key now holds plaintext that matches the captured
+      // snapshot exactly. Not toMatchObject, not toBeDefined — structural
+      // equality with the original plaintext value.
+      await assertAllKeysMatchPlaintextSnapshot(page, snapshot as Parameters<typeof assertAllKeysMatchPlaintextSnapshot>[1])
+
+      // Encryption lifecycle keys are gone.
+      expect(await page.evaluate(() => localStorage.getItem('encryption-enabled'))).not.toBe('1')
+      expect(await page.evaluate(() => localStorage.getItem('encryption-salt'))).toBeNull()
+      expect(await page.evaluate(() => localStorage.getItem('encryption-verify'))).toBeNull()
+    })
+  })
+})

--- a/e2e/fixtures/encryption.fixtures.ts
+++ b/e2e/fixtures/encryption.fixtures.ts
@@ -1,11 +1,15 @@
-import { Page, expect } from '@playwright/test'
+import { BrowserContext, Page, expect } from '@playwright/test'
+import { SENSITIVE_KEYS as SOURCE_KEYS } from '../../src/utils/encryptedStorage'
 
 /**
  * Encryption E2E fixtures.
  *
  * The 13 SENSITIVE_KEYS list is the single source of truth for envelope-shape
- * verification and roundtrip tests. It must stay in sync with
- * src/utils/encryptedStorage.ts.
+ * verification and roundtrip tests. The literal-tuple form below is required
+ * for the `SensitiveKey` union type, but it is drift-checked against the
+ * source-of-truth export from `src/utils/encryptedStorage.ts` at module load
+ * — if a 14th key is added in source without updating this file, the e2e
+ * suite refuses to load instead of silently passing over only 13 keys.
  *
  * When encryption is disabled, sensitive-key values in localStorage are
  * plaintext JSON. When encryption is enabled, each value is replaced with an
@@ -30,6 +34,19 @@ export const SENSITIVE_KEYS = [
 ] as const
 
 export type SensitiveKey = (typeof SENSITIVE_KEYS)[number]
+
+// Drift guard: if src/utils/encryptedStorage.ts gains or renames a key
+// without this fixture being updated, tests would silently pass over only
+// the keys this file knows about. Fail loudly at module load instead.
+if (
+  SOURCE_KEYS.length !== SENSITIVE_KEYS.length ||
+  SOURCE_KEYS.some(k => !(SENSITIVE_KEYS as readonly string[]).includes(k))
+) {
+  throw new Error(
+    `E2E SENSITIVE_KEYS drifted from src/utils/encryptedStorage.ts. ` +
+      `Source: [${SOURCE_KEYS.join(', ')}]. Fixture: [${SENSITIVE_KEYS.join(', ')}].`,
+  )
+}
 
 /**
  * Realistic plaintext content for each sensitive key. Shapes match what the
@@ -65,10 +82,14 @@ export function defaultPlaintextContent(): Record<SensitiveKey, unknown> {
  * values are present before EncryptionProvider mounts. Also clears the
  * encryption lifecycle keys so the app boots in the disabled state.
  *
+ * Attaches to the `BrowserContext` so every page created within the context
+ * (including tab B in cross-tab tests) inherits the seeded state regardless
+ * of which page is opened first.
+ *
  * Returns the snapshot so tests can use it for roundtrip verification.
  */
 export async function seedAllSensitiveKeys(
-  page: Page,
+  pageOrContext: Page | BrowserContext,
   content: Record<SensitiveKey, unknown> = defaultPlaintextContent(),
 ): Promise<Record<SensitiveKey, unknown>> {
   const serialized: Record<string, string> = {}
@@ -76,12 +97,20 @@ export async function seedAllSensitiveKeys(
     serialized[key] = JSON.stringify(content[key])
   }
 
-  await page.addInitScript(payload => {
-    localStorage.clear()
-    localStorage.setItem('encryption-enabled', '0')
+  await pageOrContext.addInitScript(payload => {
+    // Idempotent: runs on every new page in the context. Don't clear LS
+    // here — within a single test, multiple tabs share localStorage and
+    // clearing would wipe state set by another tab (e.g. tab A enabling
+    // encryption before tab B opens). Playwright gives each test a fresh
+    // browser context with empty localStorage by default, so no clear is
+    // needed.
     localStorage.setItem('onboarding-dismissed', '1')
     for (const [k, v] of Object.entries(payload)) {
-      localStorage.setItem(k, v)
+      // Only seed if not already set — preserves state written by other
+      // tabs in the same test.
+      if (localStorage.getItem(k) === null) {
+        localStorage.setItem(k, v)
+      }
     }
   }, serialized)
 
@@ -91,11 +120,16 @@ export async function seedAllSensitiveKeys(
 /**
  * Bare seed: clears localStorage and disables onboarding, with no sensitive
  * keys present. Use for lifecycle tests that don't care about data content.
+ *
+ * Accepts either a `Page` or a `BrowserContext`. For multi-tab tests, pass
+ * the context so every new page inherits the seeded state. For single-tab
+ * tests, passing the page is fine.
  */
-export async function seedEmptyEncryptionState(page: Page): Promise<void> {
-  await page.addInitScript(() => {
-    localStorage.clear()
-    localStorage.setItem('encryption-enabled', '0')
+export async function seedEmptyEncryptionState(pageOrContext: Page | BrowserContext): Promise<void> {
+  await pageOrContext.addInitScript(() => {
+    // Idempotent: runs on every new page in the context. See note in
+    // seedAllSensitiveKeys above — no localStorage.clear() so state written
+    // by tab A is visible to tab B when it opens.
     localStorage.setItem('onboarding-dismissed', '1')
   })
 }

--- a/e2e/fixtures/encryption.fixtures.ts
+++ b/e2e/fixtures/encryption.fixtures.ts
@@ -1,0 +1,181 @@
+import { Page, expect } from '@playwright/test'
+
+/**
+ * Encryption E2E fixtures.
+ *
+ * The 13 SENSITIVE_KEYS list is the single source of truth for envelope-shape
+ * verification and roundtrip tests. It must stay in sync with
+ * src/utils/encryptedStorage.ts.
+ *
+ * When encryption is disabled, sensitive-key values in localStorage are
+ * plaintext JSON. When encryption is enabled, each value is replaced with an
+ * `EncryptedEnvelope` of shape `{ v: 1, iv: string, ct: string }` (see
+ * src/utils/crypto.ts).
+ */
+
+export const SENSITIVE_KEYS = [
+  'user-profile',
+  'data-accounts',
+  'data-balances',
+  'budget-store',
+  'budget-summary',
+  'budget-config',
+  'tax-store',
+  'tax-templates',
+  'financialGoals',
+  'gw-goals',
+  'fi-simulations',
+  'allocation-custom-ratios',
+  'sgt-overrides',
+] as const
+
+export type SensitiveKey = (typeof SENSITIVE_KEYS)[number]
+
+/**
+ * Realistic plaintext content for each sensitive key. Shapes match what the
+ * app would persist normally — minimal but valid JSON the app can parse.
+ * Used by `seedAllSensitiveKeys` and the test-10 roundtrip snapshot.
+ */
+export function defaultPlaintextContent(): Record<SensitiveKey, unknown> {
+  return {
+    'user-profile': { name: 'Test User', avatarDataUrl: '', birthday: '1990-01-01' },
+    'data-accounts': [
+      { id: 1, name: 'Checking', type: 'cash', owner: 'self' },
+      { id: 2, name: '401k', type: 'retirement', owner: 'self' },
+    ],
+    'data-balances': [
+      { id: 1, accountId: 1, month: '2024-01', balance: 1000 },
+      { id: 2, accountId: 2, month: '2024-01', balance: 50000 },
+    ],
+    'budget-store': { csvs: {}, configs: {}, years: [2024] },
+    'budget-summary': { annualSavings: 12000, saveRate: 0.25, monthsOfData: 6 },
+    'budget-config': { version: 1, years: [2024], categoryGroups: [] },
+    'tax-store': { years: { 2024: { items: [] } } },
+    'tax-templates': [{ id: 'tpl-1', name: 'Default', items: [] }],
+    financialGoals: [{ id: 'g-1', goalName: 'Retirement', createdAt: '2024-01-01', birthday: '1990-01-01' }],
+    'gw-goals': [{ id: 'gw-1', fiGoalId: 'g-1', label: 'House', createdAt: '2024-01-01' }],
+    'fi-simulations': [{ id: 'sim-1', name: 'Baseline' }],
+    'allocation-custom-ratios': { stocks: 0.6, bonds: 0.3, cash: 0.1 },
+    'sgt-overrides': { '2024-01': { delta: 100 } },
+  }
+}
+
+/**
+ * Seed plaintext JSON for all 13 sensitive keys via `addInitScript` so the
+ * values are present before EncryptionProvider mounts. Also clears the
+ * encryption lifecycle keys so the app boots in the disabled state.
+ *
+ * Returns the snapshot so tests can use it for roundtrip verification.
+ */
+export async function seedAllSensitiveKeys(
+  page: Page,
+  content: Record<SensitiveKey, unknown> = defaultPlaintextContent(),
+): Promise<Record<SensitiveKey, unknown>> {
+  const serialized: Record<string, string> = {}
+  for (const key of SENSITIVE_KEYS) {
+    serialized[key] = JSON.stringify(content[key])
+  }
+
+  await page.addInitScript(payload => {
+    localStorage.clear()
+    localStorage.setItem('encryption-enabled', '0')
+    localStorage.setItem('onboarding-dismissed', '1')
+    for (const [k, v] of Object.entries(payload)) {
+      localStorage.setItem(k, v)
+    }
+  }, serialized)
+
+  return content
+}
+
+/**
+ * Bare seed: clears localStorage and disables onboarding, with no sensitive
+ * keys present. Use for lifecycle tests that don't care about data content.
+ */
+export async function seedEmptyEncryptionState(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.clear()
+    localStorage.setItem('encryption-enabled', '0')
+    localStorage.setItem('onboarding-dismissed', '1')
+  })
+}
+
+/**
+ * Read the raw value at `key` from localStorage and JSON-parse it. Returns
+ * `null` if the key is missing.
+ */
+export async function readEnvelope(page: Page, key: string): Promise<unknown> {
+  return page.evaluate(k => {
+    const raw = localStorage.getItem(k)
+    if (raw === null) return null
+    try {
+      return JSON.parse(raw)
+    } catch {
+      return raw
+    }
+  }, key)
+}
+
+/**
+ * Type guard for the `EncryptedEnvelope` shape produced by
+ * `src/utils/crypto.ts`: `{ v: 1, iv: string, ct: string }`.
+ */
+export function isEnvelope(obj: unknown): obj is { v: number; iv: string; ct: string } {
+  if (!obj || typeof obj !== 'object') return false
+  const o = obj as Record<string, unknown>
+  return (
+    'v' in o &&
+    'iv' in o &&
+    'ct' in o &&
+    typeof o.iv === 'string' &&
+    typeof o.ct === 'string' &&
+    o.iv.length > 0 &&
+    o.ct.length > 0
+  )
+}
+
+/**
+ * Verify every sensitive key holds an `EncryptedEnvelope`. One assertion per
+ * key with the key name in the failure message — when a future regression
+ * leaks plaintext, the test report names exactly which key.
+ */
+export async function assertAllKeysAreEnvelopes(page: Page): Promise<void> {
+  for (const key of SENSITIVE_KEYS) {
+    const envelope = await readEnvelope(page, key)
+    expect(envelope, `${key} should be envelope-encrypted but was missing from localStorage`).not.toBeNull()
+    expect(isEnvelope(envelope), `${key} missing v/iv/ct envelope shape (got ${JSON.stringify(envelope)})`).toBe(true)
+  }
+}
+
+/**
+ * Verify every sensitive key holds plaintext content that matches the
+ * snapshot. Plaintext = parsed JSON value that is NOT an envelope.
+ */
+export async function assertAllKeysMatchPlaintextSnapshot(
+  page: Page,
+  snapshot: Record<SensitiveKey, unknown>,
+): Promise<void> {
+  for (const key of SENSITIVE_KEYS) {
+    const value = await readEnvelope(page, key)
+    expect(value, `${key} should be present as plaintext after disable but was missing`).not.toBeNull()
+    expect(isEnvelope(value), `${key} should be plaintext after disable but still has envelope shape`).toBe(false)
+    expect(value, `${key} plaintext content does not match pre-encrypt snapshot`).toEqual(snapshot[key])
+  }
+}
+
+/**
+ * Simulate another tab dispatching the cross-tab lock signal. The real
+ * cross-tab mechanism (src/utils/appStorage.ts) writes
+ * `_encryption-lock-signal` to localStorage, which fires a native `storage`
+ * event in every OTHER tab. Each receiving tab dispatches the
+ * `encryption-remote-lock` CustomEvent in its own window, which the
+ * EncryptionContext listens for and clears the in-memory key.
+ *
+ * In a single-tab test, the writer never receives its own storage event, so
+ * calling this in tab A only locks OTHER tabs.
+ */
+export async function dispatchRemoteLock(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    localStorage.setItem('_encryption-lock-signal', String(Date.now()))
+  })
+}

--- a/e2e/pages/security.page.ts
+++ b/e2e/pages/security.page.ts
@@ -1,0 +1,129 @@
+import { Page, Locator, expect } from '@playwright/test'
+
+/**
+ * Page object for the Security pane inside the Settings modal.
+ *
+ * The pane has four mutually-exclusive form modes (`none` | `setup` | `change`
+ * | `disable`), each with its own form and submit button. The trigger
+ * buttons and the form submit buttons sometimes share label text (e.g.
+ * "Enable Encryption", "Disable Encryption") — but the source ensures only
+ * one is mounted at a time, so plain role-based queries work without
+ * disambiguation.
+ */
+export class SecurityPage {
+  readonly page: Page
+
+  // Modal scaffolding
+  readonly settingsButton: Locator
+  readonly settingsModal: Locator
+  readonly securityNavBtn: Locator
+  readonly heading: Locator
+
+  // Status indicator (role="status" with aria-live="polite")
+  readonly status: Locator
+
+  // Setup (enable) flow
+  readonly enableTriggerBtn: Locator
+  readonly setupForm: Locator
+  readonly setupPassInput: Locator
+  readonly setupConfirmInput: Locator
+  readonly setupSubmitBtn: Locator
+  readonly setupConfirmError: Locator
+
+  // Change-passphrase flow
+  readonly changeTriggerBtn: Locator
+  readonly changeForm: Locator
+  readonly changeCurrentInput: Locator
+  readonly changeNewInput: Locator
+  readonly changeConfirmInput: Locator
+  readonly changeSubmitBtn: Locator
+  readonly changeError: Locator
+  readonly successFlash: Locator
+
+  // Disable flow
+  readonly disableTriggerBtn: Locator
+  readonly disableForm: Locator
+  readonly disablePassInput: Locator
+  readonly disableSubmitBtn: Locator
+  readonly disableError: Locator
+
+  constructor(page: Page) {
+    this.page = page
+
+    this.settingsButton = page.getByRole('button', { name: 'Settings' })
+    this.settingsModal = page.getByRole('dialog')
+    this.securityNavBtn = this.settingsModal.getByRole('button', { name: 'Security', exact: true })
+    this.heading = this.settingsModal.getByRole('heading', { name: 'Security', level: 3 })
+
+    this.status = this.settingsModal.getByRole('status').first()
+
+    this.enableTriggerBtn = this.settingsModal.getByRole('button', { name: 'Enable Encryption', exact: true })
+    this.setupForm = this.settingsModal.locator('form.security-setup-form')
+    this.setupPassInput = this.setupForm.getByLabel('New passphrase', { exact: true })
+    this.setupConfirmInput = this.setupForm.getByLabel('Confirm passphrase', { exact: true })
+    this.setupSubmitBtn = this.setupForm.getByRole('button', { name: /^Enable Encryption$|^Encrypting…$/ })
+    // PassphraseInput renders <p role="alert"> for every field (empty when no
+    // error); scope to the confirm input's specific error region by its id.
+    this.setupConfirmError = this.setupForm.locator('#setup-confirm-error')
+
+    this.changeTriggerBtn = this.settingsModal.getByRole('button', { name: 'Change Passphrase', exact: true })
+    this.changeForm = this.settingsModal.locator('form.security-change-form')
+    this.changeCurrentInput = this.changeForm.getByLabel('Current passphrase', { exact: true })
+    this.changeNewInput = this.changeForm.getByLabel('New passphrase', { exact: true })
+    this.changeConfirmInput = this.changeForm.getByLabel('Confirm new passphrase', { exact: true })
+    this.changeSubmitBtn = this.changeForm.getByRole('button', { name: /^Update Passphrase$|^Updating…$/ })
+    this.changeError = this.changeForm.locator('#change-current-error')
+    this.successFlash = this.settingsModal.locator('.settings-save-flash')
+
+    this.disableTriggerBtn = this.settingsModal.getByRole('button', { name: 'Disable Encryption', exact: true })
+    this.disableForm = this.settingsModal.locator('form.security-disable-confirm')
+    this.disablePassInput = this.disableForm.getByLabel('Enter passphrase to confirm', { exact: true })
+    this.disableSubmitBtn = this.disableForm.getByRole('button', { name: /^Disable Encryption$|^Disabling…$/ })
+    this.disableError = this.disableForm.locator('#disable-passphrase-error')
+  }
+
+  /** Navigate to the app root and open Settings → Security. */
+  async open(): Promise<void> {
+    await this.page.goto('/finance-tracking/')
+    await this.page.waitForLoadState('domcontentloaded')
+    await this.settingsButton.click()
+    await this.settingsModal.waitFor({ state: 'visible' })
+    await this.securityNavBtn.click()
+    await expect(this.heading).toBeVisible()
+  }
+
+  /** Drive the enable flow to completion. Asserts the status indicator
+   *  flips to "Encryption enabled" before returning. */
+  async enable(passphrase: string, confirm: string = passphrase): Promise<void> {
+    await this.enableTriggerBtn.click()
+    await expect(this.setupForm).toBeVisible()
+    await this.setupPassInput.fill(passphrase)
+    await this.setupConfirmInput.fill(confirm)
+    await this.setupSubmitBtn.click()
+    await expect(this.setupForm).toBeHidden()
+    await expect(this.status).toHaveText(/Encryption enabled/)
+  }
+
+  /** Drive the change-passphrase flow. Asserts the success flash appears. */
+  async changePassphrase(current: string, next: string, confirm: string = next): Promise<void> {
+    await this.changeTriggerBtn.click()
+    await expect(this.changeForm).toBeVisible()
+    await this.changeCurrentInput.fill(current)
+    await this.changeNewInput.fill(next)
+    await this.changeConfirmInput.fill(confirm)
+    await this.changeSubmitBtn.click()
+    await expect(this.changeForm).toBeHidden()
+    await expect(this.successFlash).toBeVisible()
+  }
+
+  /** Drive the disable flow to completion. Asserts the status indicator
+   *  flips back to "Encryption disabled" before returning. */
+  async disable(passphrase: string): Promise<void> {
+    await this.disableTriggerBtn.click()
+    await expect(this.disableForm).toBeVisible()
+    await this.disablePassInput.fill(passphrase)
+    await this.disableSubmitBtn.click()
+    await expect(this.disableForm).toBeHidden()
+    await expect(this.status).toHaveText(/Encryption disabled/)
+  }
+}

--- a/src/contexts/EncryptionContext.test.tsx
+++ b/src/contexts/EncryptionContext.test.tsx
@@ -5,6 +5,7 @@ vi.unmock('./EncryptionContext')
 import { render, screen, act } from '@testing-library/react'
 import { renderHook } from '@testing-library/react'
 import { EncryptionProvider, useEncryption } from './EncryptionContext'
+import { appStorage } from '../utils/appStorage'
 import type { ReactNode } from 'react'
 
 /* ── helpers ─────────────────────────────────────────────────────── */
@@ -686,6 +687,88 @@ describe('EncryptionContext', () => {
       })
 
       expect(result.current.isEncryptionEnabled).toBe(beforeEnabled)
+    })
+
+    it('ignores malformed encryption-enabled values (e.g. "2", "true")', () => {
+      // The handler should only react to "1", null, or "0". Any other value
+      // is silently ignored so a future refactor doesn't accidentally flip
+      // state on garbage input.
+      const { result } = renderHook(() => useEncryption(), { wrapper })
+      const beforeEnabled = result.current.isEncryptionEnabled
+      const beforeLocked = result.current.isLocked
+
+      for (const garbage of ['2', 'true', '', 'yes']) {
+        act(() => {
+          window.dispatchEvent(
+            new StorageEvent('storage', { key: 'encryption-enabled', newValue: garbage, oldValue: null }),
+          )
+        })
+        expect(result.current.isEncryptionEnabled).toBe(beforeEnabled)
+        expect(result.current.isLocked).toBe(beforeLocked)
+      }
+    })
+
+    it('calls appStorage.disposeLocalState() and setMode("enabled") on remote-enable', () => {
+      const disposeSpy = vi.spyOn(appStorage, 'disposeLocalState')
+      const setModeSpy = vi.spyOn(appStorage, 'setMode')
+      renderHook(() => useEncryption(), { wrapper })
+
+      // Mount calls setMode once with the initial mode — clear so we only
+      // assert on the listener's side effects.
+      disposeSpy.mockClear()
+      setModeSpy.mockClear()
+
+      act(() => {
+        window.dispatchEvent(new StorageEvent('storage', { key: 'encryption-enabled', newValue: '1', oldValue: null }))
+      })
+
+      // disposeLocalState() is what clears _memoryStore + _pendingPersists
+      // + _isReady. Without it, plaintext queued from disabled mode could
+      // leak. We use disposeLocalState rather than lock() to avoid emitting
+      // the cross-tab lock signal back to the tab that just enabled.
+      expect(disposeSpy).toHaveBeenCalledTimes(1)
+      expect(setModeSpy).toHaveBeenCalledWith('enabled')
+
+      disposeSpy.mockRestore()
+      setModeSpy.mockRestore()
+    })
+
+    it('calls appStorage.disposeLocalState() and setMode("disabled") on remote-disable', () => {
+      localStorage.setItem('encryption-enabled', '1')
+      const disposeSpy = vi.spyOn(appStorage, 'disposeLocalState')
+      const setModeSpy = vi.spyOn(appStorage, 'setMode')
+      renderHook(() => useEncryption(), { wrapper })
+
+      disposeSpy.mockClear()
+      setModeSpy.mockClear()
+
+      act(() => {
+        window.dispatchEvent(new StorageEvent('storage', { key: 'encryption-enabled', newValue: null, oldValue: '1' }))
+      })
+
+      expect(disposeSpy).toHaveBeenCalledTimes(1)
+      expect(setModeSpy).toHaveBeenCalledWith('disabled')
+
+      disposeSpy.mockRestore()
+      setModeSpy.mockRestore()
+    })
+
+    it('removes the storage listener on unmount (no handler fires after teardown)', () => {
+      const disposeSpy = vi.spyOn(appStorage, 'disposeLocalState')
+      const { unmount } = renderHook(() => useEncryption(), { wrapper })
+
+      unmount()
+      disposeSpy.mockClear()
+
+      // After unmount the listener must be gone — dispatching the event
+      // should not call appStorage.disposeLocalState(). If the cleanup ever
+      // breaks, this fires.
+      act(() => {
+        window.dispatchEvent(new StorageEvent('storage', { key: 'encryption-enabled', newValue: '1', oldValue: null }))
+      })
+
+      expect(disposeSpy).not.toHaveBeenCalled()
+      disposeSpy.mockRestore()
     })
   })
 

--- a/src/contexts/EncryptionContext.test.tsx
+++ b/src/contexts/EncryptionContext.test.tsx
@@ -645,6 +645,50 @@ describe('EncryptionContext', () => {
     })
   })
 
+  describe('cross-tab encryption-enabled propagation', () => {
+    it('flips into locked state when another tab sets encryption-enabled to "1"', () => {
+      // This tab boots in disabled mode
+      const { result } = renderHook(() => useEncryption(), { wrapper })
+      expect(result.current.isEncryptionEnabled).toBe(false)
+      expect(result.current.isLocked).toBe(false)
+
+      // Simulate another tab enabling encryption
+      act(() => {
+        window.dispatchEvent(new StorageEvent('storage', { key: 'encryption-enabled', newValue: '1', oldValue: null }))
+      })
+
+      expect(result.current.isEncryptionEnabled).toBe(true)
+      expect(result.current.cryptoKey).toBeNull()
+      expect(result.current.isLocked).toBe(true)
+    })
+
+    it('flips back to disabled when another tab clears encryption-enabled', async () => {
+      localStorage.setItem('encryption-enabled', '1')
+      const { result } = renderHook(() => useEncryption(), { wrapper })
+      expect(result.current.isEncryptionEnabled).toBe(true)
+
+      act(() => {
+        window.dispatchEvent(new StorageEvent('storage', { key: 'encryption-enabled', newValue: null, oldValue: '1' }))
+      })
+
+      expect(result.current.isEncryptionEnabled).toBe(false)
+      expect(result.current.isLocked).toBe(false)
+    })
+
+    it('ignores storage events for unrelated keys', () => {
+      const { result } = renderHook(() => useEncryption(), { wrapper })
+      const beforeEnabled = result.current.isEncryptionEnabled
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', { key: 'unrelated-key', newValue: 'whatever', oldValue: null }),
+        )
+      })
+
+      expect(result.current.isEncryptionEnabled).toBe(beforeEnabled)
+    })
+  })
+
   describe('disableEncryption edge cases', () => {
     it('returns false when no salt is present', async () => {
       localStorage.setItem('encryption-enabled', '1')

--- a/src/contexts/EncryptionContext.tsx
+++ b/src/contexts/EncryptionContext.tsx
@@ -117,13 +117,24 @@ export const EncryptionProvider: FC<{ children: ReactNode }> = ({ children }) =>
     const handler = (e: StorageEvent) => {
       if (e.key !== LS_ENABLED) return
       if (e.newValue === '1') {
+        // Disposal first: disposeLocalState() clears _memoryStore, drops
+        // _pendingPersists (so any queued plaintext write from disabled
+        // mode cannot flush to LS after this point), and flips _isReady
+        // to false. This closes the stale-tab plaintext gap that motivated
+        // the listener — setCryptoKey(null) alone left _memoryStore and
+        // _pendingPersists intact. We use disposeLocalState rather than
+        // lock() because lock() emits `_encryption-lock-signal` to other
+        // tabs, which would loop back and lock the tab that just enabled.
+        appStorage.disposeLocalState()
         appStorage.setMode('enabled')
-        appStorage.setCryptoKey(null)
         setCryptoKey(null)
         setIsEncryptionEnabled(true)
       } else if (e.newValue === null || e.newValue === '0') {
+        // Same disposal for remote-disable: drop any queued persists tied
+        // to the old enabled-mode cryptoKey and clear stale memory before
+        // flipping to disabled mode.
+        appStorage.disposeLocalState()
         appStorage.setMode('disabled')
-        appStorage.setCryptoKey(null)
         setCryptoKey(null)
         setIsEncryptionEnabled(false)
       }

--- a/src/contexts/EncryptionContext.tsx
+++ b/src/contexts/EncryptionContext.tsx
@@ -106,6 +106,32 @@ export const EncryptionProvider: FC<{ children: ReactNode }> = ({ children }) =>
     return () => window.removeEventListener('encryption-remote-lock', handler)
   }, [])
 
+  // Cross-tab `encryption-enabled` propagation. The existing
+  // `_encryption-lock-signal` mechanism propagates lock events, but a tab
+  // that was already mounted before another tab enabled encryption would
+  // otherwise keep operating in the unencrypted state — a stale-tab security
+  // gap. This listener fires on the native browser `storage` event when
+  // another tab toggles `encryption-enabled`, and forces this tab into the
+  // locked or disabled state to match.
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== LS_ENABLED) return
+      if (e.newValue === '1') {
+        appStorage.setMode('enabled')
+        appStorage.setCryptoKey(null)
+        setCryptoKey(null)
+        setIsEncryptionEnabled(true)
+      } else if (e.newValue === null || e.newValue === '0') {
+        appStorage.setMode('disabled')
+        appStorage.setCryptoKey(null)
+        setCryptoKey(null)
+        setIsEncryptionEnabled(false)
+      }
+    }
+    window.addEventListener('storage', handler)
+    return () => window.removeEventListener('storage', handler)
+  }, [])
+
   const isLocked = isEncryptionEnabled && cryptoKey === null
 
   const unlock = useCallback(async (passphrase: string): Promise<boolean> => {

--- a/src/utils/appStorage.ts
+++ b/src/utils/appStorage.ts
@@ -230,6 +230,28 @@ function lock(): void {
   _pendingPersists.clear()
 }
 
+/**
+ * Same disposal as `lock()` but does NOT write `_encryption-lock-signal`.
+ * Used by the EncryptionContext cross-tab listener when another tab toggles
+ * `encryption-enabled`: this tab needs to clear its in-memory key, drop
+ * queued plaintext persists, and flip `_isReady` to false — but emitting
+ * the lock signal would loop back and lock the tab that just enabled (the
+ * one with the real cryptoKey), defeating the whole flow.
+ *
+ * Clears _memoryStore for sensitive keys, drops _pendingPersists (so no
+ * queued plaintext write from disabled-mode flushes after this point),
+ * nulls _cryptoKey, and sets _isReady = false.
+ */
+function disposeLocalState(): void {
+  for (const key of SENSITIVE_KEYS) {
+    _memoryStore.delete(key)
+    notifySubscribers(key, null)
+  }
+  _cryptoKey = null
+  _isReady = false
+  _pendingPersists.clear()
+}
+
 function setMode(mode: 'disabled' | 'enabled'): void {
   _mode = mode
   if (mode === 'disabled') {
@@ -265,6 +287,7 @@ export const appStorage = {
   subscribe,
   hydrate,
   lock,
+  disposeLocalState,
   isReady,
   setMode,
   setCryptoKey,


### PR DESCRIPTION
## What

E2E coverage for the encryption surface plus a real cross-tab security fix.

**10 Playwright E2E tests** in 3 describe blocks (Lifecycle, Cross-Tab, Envelope Verification):
- Security pane lifecycle: enable, mismatched-confirm rejection, change passphrase (with key-rotation roundtrip — new passphrase unlocks, old fails), disable, wrong-passphrase-on-disable preserves all 13 envelopes
- Cross-tab: lock signal via `encryption-remote-lock` CustomEvent; remote enable via native browser `storage` event
- Envelope verification: enable converts all 13 sensitive keys to `{ v, iv, ct }`; disable roundtrips back to the exact post-normalization plaintext snapshot (one assertion per key with named failure messages)

**Source change:** `EncryptionContext` now reacts to cross-tab `storage` events on the `encryption-enabled` key. When a remote tab enables encryption, the local tab disposes plaintext memory and locks the UI; when a remote tab disables, the local tab reverts to disabled. This closes the stale-tab gap where one tab could remain unlocked while another enabled encryption.

To avoid a lock-signal cascade (using `lock()` would write `_encryption-lock-signal`, which would bounce back to the tab that just enabled encryption and clobber its newly-derived key), a new method `appStorage.disposeLocalState()` provides the same disposal semantics as `lock()` without the broadcast. It clears `_memoryStore`, drains `_pendingPersists`, nulls `_cryptoKey`, and flips `_isReady=false` — before the mode flip — guaranteeing no plaintext residence point survives a remote-enable.

## Review history

| Round | Alex | Casey | Reese |
|---|---|---|---|
| 1 (`d23cf59`) | ✅ SHIP (2 🟡 → follow-ups #129, #130) | 🟡 SHIP-WITH-FIXES (SENSITIVE_KEYS drift, listener unit tests, context-scoped seed) | 🟠 ADDRESS BEFORE SHIP (listener didn't fully close the plaintext-residence gap) |
| 2 (`0fed45c`) | ✅ SHIP | ✅ SHIP re-stamped | ✅ SECURITY CLEAR |

## Verification

- 10/10 encryption tests pass on 3 consecutive runs (~4.4s each)
- 214/214 full E2E suite green
- 2684/2684 unit tests green (incl. 4 new tests covering the cross-tab listener: enable spy, disable spy, malformed-value rejection, unmount cleanup)
- Anti-pattern grep: zero matches on `.catch(()=>...)`, `waitForTimeout`, `toMatchObject({})`, `toBeDefined()$`, `if (await ...isVisible())`
- `SENSITIVE_KEYS` imported from source-of-truth with belt-and-suspenders module-load drift check

## Spec adaptations from #127 (all documented inline)

1. `encryption-enabled` value is `'1'` not `'true'` — confirmed against `EncryptionContext` constants
2. Id-based error locators (`#setup-confirm-error`, etc.) instead of `getByRole('alert')` — `PassphraseInput` renders empty alert nodes per field, causing strict-mode violations (follow-up #130)
3. Test 4 key-rotation bonus uses in-page `encryption-remote-lock` CustomEvent instead of `dispatchRemoteLock + reload()` — `addInitScript` re-runs on reload and wipes seeded salt/verify state
4. Test 10 snapshots LS plaintext AFTER navigation/boot, not from seed payload — `BudgetContext` normalizes `budget-config.categoryGroups` on boot

## Follow-up issues filed

- #129 — appStorage cross-tab storage-listener envelope/mode race (pre-existing, surfaced by this PR)
- #130 — `PassphraseInput` renders empty `<p role="alert">` unconditionally (a11y smell + forces id-based locators)

## Files

- `e2e/encryption.spec.ts` (new) — 10 tests
- `e2e/fixtures/encryption.fixtures.ts` (new) — `SENSITIVE_KEYS` imported from source + helpers
- `e2e/pages/security.page.ts` (new) — `SecurityPage` object
- `src/utils/appStorage.ts` — new `disposeLocalState()` method
- `src/contexts/EncryptionContext.tsx` — cross-tab `storage` listener using `disposeLocalState()`
- `src/contexts/EncryptionContext.test.tsx` — 4 new unit tests

Closes #127

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
