### PR TITLE
test(e2e): Settings non-security + Import/Export + Modal (#128)

### DIFF
--- a/e2e/fixtures/settings.fixtures.ts
+++ b/e2e/fixtures/settings.fixtures.ts
@@ -1,0 +1,305 @@
+import { Page } from '@playwright/test'
+
+/**
+ * Seed helpers for Settings E2E tests (#128).
+ *
+ * The whole settings suite runs with encryption disabled (the default), so
+ * sensitive keys can be seeded as plaintext JSON in localStorage and the
+ * app reads them through appStorage's pass-through mode.
+ *
+ * Profile shape mirrors src/hooks/useProfile.ts — partner data is stored
+ * NESTED under `partner` inside the `user-profile` JSON value (NOT as
+ * separate partner-name / partner-birthday keys).
+ */
+
+export interface ProfilePartner {
+  name: string
+  birthday: string
+  avatarDataUrl: string
+}
+
+export interface ProfileShape {
+  name: string
+  birthday: string
+  avatarDataUrl: string
+  partner?: ProfilePartner | null
+}
+
+export interface SeedProfileOptions {
+  name?: string
+  birthday?: string
+  partner?: ProfilePartner | null
+}
+
+// ── Profile seeders ────────────────────────────────────────────────
+
+/**
+ * Seed `user-profile` with the given fields (encryption disabled).
+ * Pass `undefined` (or omit) to leave the key unwritten — equivalent to
+ * a fresh install with no profile.
+ */
+export async function seedProfile(page: Page, options: SeedProfileOptions = {}) {
+  const profile: ProfileShape = {
+    name: options.name ?? '',
+    birthday: options.birthday ?? '',
+    avatarDataUrl: '',
+    partner: options.partner ?? null,
+  }
+  await page.addInitScript(p => {
+    // Guard so reloads triggered by the app (factory reset, import) don't
+    // re-seed and clobber in-app changes the test just made.
+    if (sessionStorage.getItem('__settings_e2e_seeded')) return
+    localStorage.clear()
+    localStorage.setItem('encryption-enabled', '0')
+    localStorage.setItem('onboarding-dismissed', '1')
+    localStorage.setItem('user-profile', JSON.stringify(p))
+    sessionStorage.setItem('__settings_e2e_seeded', '1')
+  }, profile)
+}
+
+/**
+ * Clear all app storage (no profile, no settings). Used by test 13
+ * (empty profile graceful render) and as the generic "fresh app" seed.
+ */
+export async function seedEmpty(page: Page) {
+  await page.addInitScript(() => {
+    if (sessionStorage.getItem('__settings_e2e_seeded')) return
+    localStorage.clear()
+    localStorage.setItem('encryption-enabled', '0')
+    localStorage.setItem('onboarding-dismissed', '1')
+    sessionStorage.setItem('__settings_e2e_seeded', '1')
+  })
+}
+
+// ── All-data seed for export test 20 ───────────────────────────────
+
+/**
+ * Realistic content for every v2 export top-level key. Values are
+ * minimal but non-empty so that the exported JSON's keys can be
+ * compared structurally AND we can confirm no key is null/missing.
+ *
+ * The shape of each value mirrors what the app would persist after a
+ * user has interacted with every feature (one goal, one account, one
+ * balance, one budget month, one tax year, etc).
+ */
+export const ALL_DATA_PROFILE: ProfileShape = {
+  name: 'Quinn',
+  birthday: '1990-04-15',
+  avatarDataUrl: '',
+  partner: null,
+}
+
+export const ALL_DATA_GOAL = {
+  id: 1,
+  goalName: 'Retire',
+  fiGoal: 2_000_000,
+  goalCreatedIn: 2024,
+  goalEndYear: 2050,
+  currentAmount: 50_000,
+  expenseValue2047: 80_000,
+  safeWithdrawalRate: 4,
+}
+
+export const ALL_DATA_GW_GOAL = {
+  id: 100,
+  fiGoalId: 1,
+  label: 'House Down Payment',
+  amount: 100_000,
+  targetYear: 2028,
+}
+
+export const ALL_DATA_ACCOUNT = { id: 1, name: 'Checking', type: 'checking' }
+export const ALL_DATA_BALANCE = { id: 1, accountId: 1, month: '2024-01', balance: 12_345 }
+
+export const ALL_DATA_BUDGET_STORE = {
+  csvs: {
+    '2024-01': {
+      month: '2024-01',
+      csv: 'Date,Category,Amount,Description\n2024-01-01,Salary,5000,Paycheck',
+      uploadedAt: '2024-01-15T00:00:00.000Z',
+    },
+  },
+  configs: {},
+  years: [2024],
+  categoryGroups: [{ id: 'g1', name: 'Income', categories: ['Salary'] }],
+}
+
+export const ALL_DATA_BUDGET_CONFIG = {
+  years: [2024],
+  categoryGroups: [{ id: 'g1', name: 'Income', categories: ['Salary'] }],
+}
+
+export const ALL_DATA_TAX_STORE = {
+  years: {
+    2024: {
+      items: [
+        { id: 'item-1', label: 'W-2', owner: 'primary', category: 'paystub', accountIds: [], files: [] },
+      ],
+    },
+  },
+}
+
+export const ALL_DATA_TAX_TEMPLATE = {
+  id: 'tpl-1',
+  name: 'Default',
+  items: [{ id: 'item-1', label: 'W-2', owner: 'primary', category: 'paystub' }],
+}
+
+export const ALL_DATA_FI_SIMULATIONS = [{ id: 1, label: 'Base case', value: 1.05 }]
+export const ALL_DATA_SGT_OVERRIDES = { '2024-01': { Salary: 1 } }
+export const ALL_DATA_ALLOCATION_RATIOS = [{ name: 'Stocks', ratio: 0.7 }]
+
+/**
+ * Seed every key that `handleExport` reads, plus the three non-sensitive
+ * settings keys included in the exported `settings` block.
+ */
+export async function seedAllData(page: Page) {
+  await page.addInitScript(
+    payload => {
+      if (sessionStorage.getItem('__settings_e2e_seeded')) return
+      localStorage.clear()
+      localStorage.setItem('encryption-enabled', '0')
+      localStorage.setItem('onboarding-dismissed', '1')
+
+      // Settings (non-sensitive)
+      localStorage.setItem('darkMode', '1')
+      localStorage.setItem('accentTheme', 'blue')
+      localStorage.setItem('allowCsvImport', '1')
+      localStorage.setItem('goal-view-mode', 'grid')
+      localStorage.setItem('home-card-order', JSON.stringify([2, 0, 1, 3]))
+
+      // Sensitive: plaintext (encryption disabled)
+      localStorage.setItem('user-profile', JSON.stringify(payload.profile))
+      localStorage.setItem('financialGoals', JSON.stringify([payload.goal]))
+      localStorage.setItem('gw-goals', JSON.stringify([payload.gwGoal]))
+      localStorage.setItem('data-accounts', JSON.stringify([payload.account]))
+      localStorage.setItem('data-balances', JSON.stringify([payload.balance]))
+      localStorage.setItem('budget-store', JSON.stringify(payload.budgetStore))
+      localStorage.setItem('budget-config', JSON.stringify(payload.budgetConfig))
+      localStorage.setItem('fi-simulations', JSON.stringify(payload.fiSims))
+      localStorage.setItem('sgt-overrides', JSON.stringify(payload.sgt))
+      localStorage.setItem('allocation-custom-ratios', JSON.stringify(payload.ratios))
+      localStorage.setItem('tax-store', JSON.stringify(payload.taxStore))
+      localStorage.setItem('tax-templates', JSON.stringify([payload.taxTemplate]))
+      sessionStorage.setItem('__settings_e2e_seeded', '1')
+    },
+    {
+      profile: ALL_DATA_PROFILE,
+      goal: ALL_DATA_GOAL,
+      gwGoal: ALL_DATA_GW_GOAL,
+      account: ALL_DATA_ACCOUNT,
+      balance: ALL_DATA_BALANCE,
+      budgetStore: ALL_DATA_BUDGET_STORE,
+      budgetConfig: ALL_DATA_BUDGET_CONFIG,
+      fiSims: ALL_DATA_FI_SIMULATIONS,
+      sgt: ALL_DATA_SGT_OVERRIDES,
+      ratios: ALL_DATA_ALLOCATION_RATIOS,
+      taxStore: ALL_DATA_TAX_STORE,
+      taxTemplate: ALL_DATA_TAX_TEMPLATE,
+    },
+  )
+}
+
+// ── Import payload builders ────────────────────────────────────────
+
+/**
+ * Build a v1 (legacy) import payload — a bare JSON array of goals (no
+ * version field, no wrapping object). The importValidator accepts this
+ * shape via the `Array.isArray(parsed)` branch in goalsSource.
+ *
+ * Goal fields adapted to importValidator's requirements: numeric `id`
+ * and non-empty `goalName` (the spec's literal `{ id: 'g1', name: '...' }`
+ * shape would be rejected by validateGoal; tests in this suite assert
+ * the imported goal IS visible afterward, so it must pass validation).
+ */
+export function buildV1Import(): { name: string; content: string } {
+  const legacyGoal = {
+    id: 1,
+    goalName: 'FI Goal',
+    fiGoal: 2_000_000,
+    goalCreatedIn: 2024,
+    goalEndYear: 2050,
+    currentAmount: 0,
+    expenseValue2047: 80_000,
+    safeWithdrawalRate: 4,
+  }
+  return {
+    name: 'v1-import.json',
+    content: JSON.stringify([legacyGoal]),
+  }
+}
+
+/**
+ * Build a v2 import payload that includes two unknown top-level keys
+ * (`unknownField` and `futureFeature`) that the validator must silently
+ * drop — neither should appear in localStorage after import.
+ */
+export function buildV2ImportWithUnknown(): { name: string; content: string } {
+  const known = {
+    version: 2,
+    goals: [
+      {
+        id: 42,
+        goalName: 'V2 Imported Goal',
+        fiGoal: 1_500_000,
+        goalCreatedIn: 2024,
+        goalEndYear: 2050,
+        currentAmount: 100,
+        expenseValue2047: 60_000,
+        safeWithdrawalRate: 4,
+      },
+    ],
+    unknownField: 'xyz',
+    futureFeature: { nested: true, value: 42 },
+  }
+  return {
+    name: 'v2-with-unknown.json',
+    content: JSON.stringify(known),
+  }
+}
+
+// ── Reference data for assertions ──────────────────────────────────
+
+/**
+ * The 15 top-level keys that `handleExport` writes into the v2 export
+ * JSON. Sourced verbatim from src/contexts/ImportExportContext.tsx so
+ * the export test fails loudly if a key is added or removed there
+ * without a corresponding test update.
+ */
+export const V2_EXPORT_KEYS = [
+  'version',
+  'exportedAt',
+  'goals',
+  'gwGoals',
+  'profile',
+  'settings',
+  'dataAccounts',
+  'dataBalances',
+  'budgetCsvs',
+  'budgetConfig',
+  'fiSimulations',
+  'sgtOverrides',
+  'allocationCustomRatios',
+  'taxStore',
+  'taxTemplates',
+] as const
+
+/**
+ * The 13 sensitive keys defined in src/utils/encryptedStorage.ts. Every
+ * one must be cleared by Factory Reset (test 8).
+ */
+export const SENSITIVE_KEYS = [
+  'user-profile',
+  'data-accounts',
+  'data-balances',
+  'budget-store',
+  'budget-summary',
+  'budget-config',
+  'tax-store',
+  'tax-templates',
+  'financialGoals',
+  'gw-goals',
+  'fi-simulations',
+  'allocation-custom-ratios',
+  'sgt-overrides',
+] as const

--- a/e2e/fixtures/settings.fixtures.ts
+++ b/e2e/fixtures/settings.fixtures.ts
@@ -3,6 +3,14 @@ import { Page } from '@playwright/test'
 /**
  * Seed helpers for Settings E2E tests (#128).
  *
+ * Seeding strategy: each helper uses `page.addInitScript` to write
+ * localStorage BEFORE any app code runs, and guards with the
+ * `__settings_e2e_seeded` sessionStorage flag so that app-triggered
+ * reloads (factory reset, import) do not re-seed and clobber the
+ * post-action state we're trying to assert.
+ *
+ * Each helper is idempotent within a single Playwright page session.
+ *
  * The whole settings suite runs with encryption disabled (the default), so
  * sensitive keys can be seeded as plaintext JSON in localStorage and the
  * app reads them through appStorage's pass-through mode.

--- a/e2e/pages/settings.page.ts
+++ b/e2e/pages/settings.page.ts
@@ -1,0 +1,156 @@
+import { Page, Locator, expect } from '@playwright/test'
+
+/**
+ * Page object for the Settings modal — non-security panes (Profile,
+ * Appearance, Advanced, Labs) plus the modal shell and Import/Export.
+ *
+ * The Security pane has its own page object (e2e/pages/security.page.ts).
+ * This object only exposes nav items for the panes covered by #128.
+ */
+export class SettingsPage {
+  readonly page: Page
+
+  // Trigger + modal scaffolding
+  readonly settingsButton: Locator
+  readonly dialog: Locator
+  readonly backdrop: Locator
+  readonly closeButton: Locator
+
+  // Side-nav (aria-current="page" on the active item)
+  readonly navProfile: Locator
+  readonly navAppearance: Locator
+  readonly navAdvanced: Locator
+  readonly navLabs: Locator
+
+  // Pane headings (h3 inside each pane)
+  readonly profileHeading: Locator
+  readonly appearanceHeading: Locator
+  readonly advancedHeading: Locator
+  readonly labsHeading: Locator
+
+  // Profile pane
+  readonly editProfileBtn: Locator
+  readonly saveProfileBtn: Locator
+  readonly cancelProfileBtn: Locator
+  readonly profileNameInput: Locator
+  readonly profileBirthdayInput: Locator
+  readonly addPartnerBtn: Locator
+  readonly partnerNameInput: Locator
+  readonly partnerBirthdayInput: Locator
+  readonly profileSavedFlash: Locator
+  readonly viewName: Locator
+  readonly viewPartnerName: Locator
+
+  // Appearance pane
+  readonly lightThemeBtn: Locator
+  readonly darkThemeBtn: Locator
+
+  // Advanced pane
+  readonly allowCsvToggle: Locator
+  readonly exportBtn: Locator
+  readonly importBtn: Locator
+  readonly importFileInput: Locator
+  readonly factoryResetBtn: Locator
+  readonly factoryResetConfirmBtn: Locator
+
+  // Labs pane
+  readonly labPdfToCsvToggle: Locator
+  readonly demoModeToggle: Locator
+
+  constructor(page: Page) {
+    this.page = page
+
+    this.settingsButton = page.getByRole('button', { name: 'Settings' })
+    this.dialog = page.getByRole('dialog', { name: 'Settings' })
+    // The modal backdrop is the parent of role=dialog; clicking it
+    // triggers onClose via the source's stopPropagation guard.
+    this.backdrop = page.locator('.settings-modal-backdrop')
+    this.closeButton = this.dialog.getByRole('button', { name: 'Close' })
+
+    this.navProfile = this.dialog.getByRole('button', { name: 'Profile', exact: true })
+    this.navAppearance = this.dialog.getByRole('button', { name: 'Appearance', exact: true })
+    this.navAdvanced = this.dialog.getByRole('button', { name: 'Advanced', exact: true })
+    this.navLabs = this.dialog.getByRole('button', { name: 'Labs', exact: true })
+
+    this.profileHeading = this.dialog.getByRole('heading', { name: 'Profile', level: 3 })
+    this.appearanceHeading = this.dialog.getByRole('heading', { name: 'Appearance', level: 3 })
+    this.advancedHeading = this.dialog.getByRole('heading', { name: 'Advanced', level: 3 })
+    this.labsHeading = this.dialog.getByRole('heading', { name: 'Labs', level: 3 })
+
+    this.editProfileBtn = this.dialog.getByRole('button', { name: 'Edit Profile' })
+    this.saveProfileBtn = this.dialog.getByRole('button', { name: 'Save Profile' })
+    this.cancelProfileBtn = this.dialog.getByRole('button', { name: 'Cancel' })
+    // Two "Name" fields exist when partner is present — disambiguate by
+    // scoping to the primary settings-profile-card (the first one in the
+    // edit view).
+    // The profile <label> elements aren't wired to inputs via htmlFor, so
+    // we can't use getByLabel here. Scope by card + input attributes
+    // instead: each settings-profile-card (edit mode) has exactly one
+    // text input (Name, placeholder "Your name" / "Partner's name") and
+    // one date input (Birthday).
+    const editProfileCards = this.dialog.locator('.settings-profile-card:not(.settings-profile-card--view)')
+    this.profileNameInput = editProfileCards.first().locator('input[type="text"]')
+    this.profileBirthdayInput = editProfileCards.first().locator('input[type="date"]')
+    this.addPartnerBtn = this.dialog.getByRole('button', { name: '+ Add Partner' })
+    this.partnerNameInput = editProfileCards.nth(1).locator('input[type="text"]')
+    this.partnerBirthdayInput = editProfileCards.nth(1).locator('input[type="date"]')
+    this.profileSavedFlash = this.dialog.locator('.settings-save-flash')
+    this.viewName = this.dialog.locator('.settings-profile-view-name').first()
+    this.viewPartnerName = this.dialog.locator('.settings-profile-view-name').nth(1)
+
+    // Appearance buttons don't carry aria-label; their accessible names
+    // come from the nested `<span class="settings-theme-name">` text. Use
+    // class-scoped locators to avoid relying on accessible-name parsing
+    // of buttons that also contain SVG preview chrome.
+    this.lightThemeBtn = this.dialog.locator('.settings-theme-option').filter({ hasText: 'Light' })
+    this.darkThemeBtn = this.dialog.locator('.settings-theme-option').filter({ hasText: 'Dark' })
+
+    // Advanced pane toggle button has role="switch" but no accessible
+    // name on the button itself (the label is a sibling span). It's the
+    // only switch on the Advanced pane, so scope by pane heading then
+    // pick the switch role.
+    this.allowCsvToggle = this.dialog
+      .locator('.settings-section')
+      .filter({ has: page.getByRole('heading', { name: 'Advanced', level: 3 }) })
+      .getByRole('switch')
+    this.exportBtn = this.dialog.getByRole('button', { name: 'Export' })
+    this.importBtn = this.dialog.getByRole('button', { name: 'Import' })
+    this.importFileInput = this.dialog.locator('input[type="file"][accept=".json"]')
+    this.factoryResetBtn = this.dialog.getByRole('button', { name: 'Factory Reset App' })
+    this.factoryResetConfirmBtn = this.dialog.getByRole('button', { name: 'Yes, Reset Everything' })
+
+    this.labPdfToCsvToggle = this.dialog.getByRole('switch', { name: 'PDF → CSV' })
+    this.demoModeToggle = this.dialog.getByRole('switch', { name: 'Demo Mode' })
+  }
+
+  /** Navigate to the app root and open the Settings modal. */
+  async open(): Promise<void> {
+    await this.page.goto('/finance-tracking/')
+    await this.page.waitForLoadState('domcontentloaded')
+    await this.settingsButton.click()
+    await expect(this.dialog).toBeVisible()
+  }
+
+  /** Open the modal without navigating (assumes the page is already loaded). */
+  async openInPlace(): Promise<void> {
+    await this.settingsButton.click()
+    await expect(this.dialog).toBeVisible()
+  }
+
+  /**
+   * Click a nav item and wait for the matching pane heading to render.
+   * Uses aria-current="page" as the active-state contract.
+   */
+  async navTo(section: 'profile' | 'appearance' | 'advanced' | 'labs'): Promise<void> {
+    const map = {
+      profile: { btn: this.navProfile, heading: this.profileHeading },
+      appearance: { btn: this.navAppearance, heading: this.appearanceHeading },
+      advanced: { btn: this.navAdvanced, heading: this.advancedHeading },
+      labs: { btn: this.navLabs, heading: this.labsHeading },
+    }
+    const { btn, heading } = map[section]
+    await btn.click()
+    await expect(btn).toHaveAttribute('aria-current', 'page')
+    await expect(heading).toBeVisible()
+  }
+}

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,622 @@
+import { test, expect } from '@playwright/test'
+import { SettingsPage } from './pages/settings.page'
+import {
+  ALL_DATA_BALANCE,
+  ALL_DATA_GOAL,
+  buildV1Import,
+  buildV2ImportWithUnknown,
+  SENSITIVE_KEYS,
+  seedAllData,
+  seedEmpty,
+  seedProfile,
+  V2_EXPORT_KEYS,
+} from './fixtures/settings.fixtures'
+
+test.describe('Settings — Non-Security E2E', () => {
+  /* ── Settings — Profile ───────────────────────────────────────── */
+
+  test.describe('Profile', () => {
+    test('1. Opening Settings shows Profile pane by default', async ({ page }) => {
+      // (was #60 test 9) — first impression of the modal must land on
+      // Profile, with the dialog wired up so getByRole('dialog', { name }) works.
+      await seedProfile(page, { name: 'Casey', birthday: '1988-02-10' })
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      // Dialog has accessible name "Settings" via aria-labelledby.
+      await expect(settings.dialog).toBeVisible()
+      await expect(settings.dialog).toHaveAttribute('aria-modal', 'true')
+
+      // Profile is active by default (aria-current set in source, not class).
+      await expect(settings.navProfile).toHaveAttribute('aria-current', 'page')
+      await expect(settings.navAppearance).not.toHaveAttribute('aria-current')
+      await expect(settings.profileHeading).toBeVisible()
+
+      // Name + birthday surfaces are reachable in view + edit modes.
+      await expect(settings.viewName).toHaveText('Casey')
+      await settings.editProfileBtn.click()
+      await expect(settings.profileNameInput).toBeVisible()
+      await expect(settings.profileBirthdayInput).toBeVisible()
+    })
+
+    test('2. Editing profile name and saving persists the change', async ({ page }) => {
+      // (was #60 test 10) — full edit→save→reload→Home greeting loop.
+      await seedProfile(page, { name: 'Casey', birthday: '1988-02-10' })
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      await settings.editProfileBtn.click()
+      await settings.profileNameInput.fill('Alex')
+      await settings.saveProfileBtn.click()
+
+      // Success flash + view name swaps.
+      await expect(settings.profileSavedFlash).toBeVisible()
+      await expect(settings.viewName).toHaveText('Alex')
+
+      // Persisted to localStorage under user-profile (encryption disabled).
+      const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('user-profile') || '{}'))
+      expect(stored.name).toBe('Alex')
+      expect(stored.birthday).toBe('1988-02-10')
+
+      // Reload + Home greeting picks up the new name.
+      await settings.closeButton.click()
+      await page.reload()
+      await expect(page.getByRole('heading', { name: /^Good (morning|afternoon|evening), Alex$/ })).toBeVisible()
+    })
+
+    test('3. Profile supports partner toggle — adding partner fields', async ({ page }) => {
+      // (was #60 test 11) — partner is stored NESTED under `partner` inside
+      // user-profile (see src/hooks/useProfile.ts), NOT as separate keys.
+      await seedProfile(page, { name: 'Casey', birthday: '1988-02-10' })
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      await settings.editProfileBtn.click()
+      // No partner section yet → +Add Partner is the affordance.
+      await expect(settings.partnerNameInput).toHaveCount(0)
+      await settings.addPartnerBtn.click()
+
+      // Partner fields render in a second .settings-profile-card.
+      await expect(settings.partnerNameInput).toBeVisible()
+      await expect(settings.partnerBirthdayInput).toBeVisible()
+      await settings.partnerNameInput.fill('Jordan')
+      await settings.partnerBirthdayInput.fill('1990-07-04')
+      await settings.saveProfileBtn.click()
+
+      await expect(settings.profileSavedFlash).toBeVisible()
+      await expect(settings.viewPartnerName).toHaveText('Jordan')
+
+      // Storage shape: partner object nested under `partner` key.
+      const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('user-profile') || '{}'))
+      expect(stored.partner).toBeTruthy()
+      expect(stored.partner.name).toBe('Jordan')
+      expect(stored.partner.birthday).toBe('1990-07-04')
+      // The shape uses one nested object, NOT separate partner-name keys.
+      const keys = await page.evaluate(() => Object.keys(localStorage))
+      expect(keys).not.toContain('partner-name')
+      expect(keys).not.toContain('partner-birthday')
+    })
+
+    test('4. Canceling profile edit reverts changes', async ({ page }) => {
+      // (was #60 test 12) — Cancel must NOT touch localStorage.
+      await seedProfile(page, { name: 'Casey', birthday: '1988-02-10' })
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      const before = await page.evaluate(() => localStorage.getItem('user-profile'))
+
+      await settings.editProfileBtn.click()
+      await settings.profileNameInput.fill('Discarded')
+      await settings.cancelProfileBtn.click()
+
+      // View name is unchanged.
+      await expect(settings.viewName).toHaveText('Casey')
+
+      // Re-opening edit shows the original value, not the discarded one.
+      await settings.editProfileBtn.click()
+      await expect(settings.profileNameInput).toHaveValue('Casey')
+
+      // Storage is byte-for-byte unchanged.
+      const after = await page.evaluate(() => localStorage.getItem('user-profile'))
+      expect(after).toBe(before)
+    })
+  })
+
+  /* ── Settings — Appearance ────────────────────────────────────── */
+
+  test.describe('Appearance', () => {
+    test('5. Switching to Dark mode toggles theme', async ({ page }) => {
+      // (was #60 test 13) — body.dark class + darkMode='1' + aria-pressed.
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('appearance')
+
+      // Default seed: light. Light is pressed, dark is not.
+      await expect(settings.lightThemeBtn).toHaveAttribute('aria-pressed', 'true')
+      await expect(settings.darkThemeBtn).toHaveAttribute('aria-pressed', 'false')
+
+      await settings.darkThemeBtn.click()
+
+      await expect(settings.darkThemeBtn).toHaveAttribute('aria-pressed', 'true')
+      await expect(settings.lightThemeBtn).toHaveAttribute('aria-pressed', 'false')
+      await expect(page.locator('body')).toHaveClass(/\bdark\b/)
+      await expect.poll(() => page.evaluate(() => localStorage.getItem('darkMode'))).toBe('1')
+    })
+
+    test('6. Switching back to Light mode reverts theme', async ({ page }) => {
+      // (was #60 test 14) — start in dark via seed, click Light, verify revert.
+      await page.addInitScript(() => {
+        localStorage.clear()
+        localStorage.setItem('encryption-enabled', '0')
+        localStorage.setItem('onboarding-dismissed', '1')
+        localStorage.setItem('darkMode', '1')
+      })
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('appearance')
+
+      await expect(settings.darkThemeBtn).toHaveAttribute('aria-pressed', 'true')
+      await expect(page.locator('body')).toHaveClass(/\bdark\b/)
+
+      await settings.lightThemeBtn.click()
+
+      await expect(settings.lightThemeBtn).toHaveAttribute('aria-pressed', 'true')
+      await expect(settings.darkThemeBtn).toHaveAttribute('aria-pressed', 'false')
+      await expect(page.locator('body')).not.toHaveClass(/\bdark\b/)
+      await expect.poll(() => page.evaluate(() => localStorage.getItem('darkMode'))).toBe('0')
+    })
+  })
+
+  /* ── Settings — Advanced ──────────────────────────────────────── */
+
+  test.describe('Advanced', () => {
+    test('7. Advanced pane shows CSV import toggle, export, and factory reset options', async ({ page }) => {
+      // (was #60 test 21) — surface inventory only; no clicks.
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('advanced')
+
+      await expect(settings.allowCsvToggle).toBeVisible()
+      await expect(settings.allowCsvToggle).toHaveAttribute('aria-checked', 'false')
+      await expect(settings.exportBtn).toBeVisible()
+      await expect(settings.importBtn).toBeVisible()
+      await expect(settings.factoryResetBtn).toBeVisible()
+      // Confirmation button is NOT mounted until the reset CTA is clicked.
+      await expect(settings.factoryResetConfirmBtn).toHaveCount(0)
+    })
+
+    test('8. Factory Reset clears all data after confirmation', async ({ page }) => {
+      // (was #60 test 22) — enumerate every key we seeded, assert each is
+      // gone. The app's first-load effects WILL re-write a small set of
+      // settings defaults (darkMode='0', accentTheme='blue',
+      // allowCsvImport='0') plus a fresh schema version and a new
+      // flag-client-id; those survivors are documented below and do NOT
+      // carry pre-reset values.
+      await seedAllData(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      // Confirm at least one seeded sensitive key actually landed.
+      const seededBalances = await page.evaluate(() => localStorage.getItem('data-balances'))
+      expect(seededBalances).toContain(String(ALL_DATA_BALANCE.balance))
+
+      await settings.navTo('advanced')
+      await settings.factoryResetBtn.click()
+      await expect(settings.factoryResetConfirmBtn).toBeVisible()
+
+      // The reset handler calls localStorage.clear() then window.location.reload().
+      // Trigger the click and wait for the reload event before asserting state.
+      const reloadPromise = page.waitForEvent('load')
+      await settings.factoryResetConfirmBtn.click()
+      await reloadPromise
+
+      // Every seeded sensitive key is either cleared (null) or, if the
+      // app's context provider re-initialised it on cold load, holds an
+      // empty container ([] / {} / null-serialized) — never the original
+      // seeded payload. Per-key failure messages name the offender.
+      const EMPTY_REINIT_VALUES = new Set(['[]', '{}', 'null', ''])
+      for (const key of SENSITIVE_KEYS) {
+        const value = await page.evaluate(k => localStorage.getItem(k), key)
+        if (value === null) continue
+        expect(
+          EMPTY_REINIT_VALUES.has(value),
+          `sensitive key "${key}" must be cleared (got non-empty value ${value!.slice(0, 80)})`,
+        ).toBe(true)
+      }
+
+      // Non-sensitive seeded keys are gone too.
+      for (const key of ['goal-view-mode', 'home-card-order'] as const) {
+        const value = await page.evaluate(k => localStorage.getItem(k), key)
+        expect(value, `non-sensitive seeded key "${key}" must be cleared`).toBeNull()
+      }
+
+      // Documented survivors — keys the app re-writes on cold load with
+      // their default values (NOT the pre-reset seeded values).
+      const darkMode = await page.evaluate(() => localStorage.getItem('darkMode'))
+      expect(darkMode, 'darkMode survives reset as default "0", not seeded "1"').toBe('0')
+      const accentTheme = await page.evaluate(() => localStorage.getItem('accentTheme'))
+      expect(accentTheme, 'accentTheme survives reset as default "blue"').toBe('blue')
+      const allowCsv = await page.evaluate(() => localStorage.getItem('allowCsvImport'))
+      expect(allowCsv, 'allowCsvImport survives reset as default "0", not seeded "1"').toBe('0')
+      const schemaVer = await page.evaluate(() => localStorage.getItem('storage-schema-version'))
+      expect(schemaVer, 'storage-schema-version is re-written on cold start').not.toBeNull()
+    })
+  })
+
+  /* ── Settings — Labs ──────────────────────────────────────────── */
+
+  test.describe('Labs', () => {
+    test('9. Labs pane shows experimental feature toggles', async ({ page }) => {
+      // (was #60 test 23) — both lab toggles render with switch role.
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('labs')
+
+      await expect(settings.labPdfToCsvToggle).toBeVisible()
+      await expect(settings.labPdfToCsvToggle).toHaveAttribute('aria-checked', 'false')
+      await expect(settings.demoModeToggle).toBeVisible()
+      await expect(settings.demoModeToggle).toHaveAttribute('aria-checked', 'false')
+    })
+  })
+
+  /* ── Settings — Modal Behavior ────────────────────────────────── */
+
+  test.describe('Modal Behavior', () => {
+    test('10. Settings modal closes on Escape key', async ({ page }) => {
+      // (was #60 test 24) — Escape closes; focus returns to the trigger.
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      await page.keyboard.press('Escape')
+      await expect(settings.dialog).toHaveCount(0)
+
+      // useFocusTrap restores focus to the previously focused element on
+      // unmount — that's the Settings trigger button.
+      const focusedLabel = await page.evaluate(() => document.activeElement?.getAttribute('aria-label'))
+      expect(focusedLabel).toBe('Settings')
+    })
+
+    test('11. Settings modal closes on backdrop click', async ({ page }) => {
+      // (was #60 test 25) — clicking the backdrop (NOT the modal) closes.
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      // Click the corner of the backdrop (well outside the modal panel).
+      await settings.backdrop.click({ position: { x: 5, y: 5 } })
+      await expect(settings.dialog).toHaveCount(0)
+    })
+
+    test('12. Settings nav highlights active section', async ({ page }) => {
+      // (was #60 test 26) — aria-current="page" toggles on click; only one
+      // nav item carries it at a time. Pane content swaps in lockstep.
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      // Default: Profile is current, Appearance is not.
+      await expect(settings.navProfile).toHaveAttribute('aria-current', 'page')
+      await expect(settings.navAppearance).not.toHaveAttribute('aria-current')
+
+      await settings.navAppearance.click()
+      await expect(settings.navAppearance).toHaveAttribute('aria-current', 'page')
+      await expect(settings.navProfile).not.toHaveAttribute('aria-current')
+      await expect(settings.appearanceHeading).toBeVisible()
+      await expect(settings.profileHeading).toHaveCount(0)
+    })
+  })
+
+  /* ── Edge Cases ───────────────────────────────────────────────── */
+
+  test.describe('Edge Cases', () => {
+    test('13. Settings with no profile data shows empty fields gracefully', async ({ page }) => {
+      // (was #60 test 28) — no user-profile in storage; modal must mount,
+      // edit form must render empty inputs, no console errors.
+      const consoleErrors: string[] = []
+      page.on('pageerror', e => consoleErrors.push(e.message))
+
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      // View mode renders the empty-name placeholder, not a crashed pane.
+      await expect(settings.viewName).toHaveText('No name set')
+
+      await settings.editProfileBtn.click()
+      await expect(settings.profileNameInput).toHaveValue('')
+      await expect(settings.profileBirthdayInput).toHaveValue('')
+
+      expect(consoleErrors).toEqual([])
+    })
+  })
+
+  /* ── Import / Export ──────────────────────────────────────────── */
+
+  test.describe('Import / Export', () => {
+    test('14. Import v1 format JSON (legacy goal array) succeeds without crash', async ({ page }) => {
+      // (was #60 test 31) — bare-array (v1) shape goes through the
+      // Array.isArray(parsed) branch of importValidator. After import the
+      // handler reloads the app; assert the seeded goal lands in
+      // localStorage and the other pages render their empty states without
+      // error.
+      const consoleErrors: string[] = []
+      page.on('pageerror', e => consoleErrors.push(e.message))
+
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('advanced')
+
+      const v1 = buildV1Import()
+      // Note: ImportExportContext.handleImport schedules window.location.reload()
+      // 200ms after the FileReader resolves. We don't race with that — we
+      // poll for the imported value to surface in localStorage and let the
+      // reload happen in the background.
+      await settings.importFileInput.setInputFiles({
+        name: v1.name,
+        mimeType: 'application/json',
+        buffer: Buffer.from(v1.content),
+      })
+
+      // Goal is in localStorage under financialGoals (survives reload).
+      await expect
+        .poll(() => page.evaluate(() => localStorage.getItem('financialGoals')), { timeout: 10_000 })
+        .toContain('FI Goal')
+      // Ensure the post-import reload has settled before we navigate.
+      await page.waitForLoadState('domcontentloaded')
+
+      // Net Worth, Budget, Taxes each render their empty states with no
+      // console errors. We visit each route directly.
+      await page.goto('/finance-tracking/#/net-worth')
+      await expect(page.getByRole('heading', { name: 'Net Worth' })).toBeVisible()
+      await page.goto('/finance-tracking/#/budget')
+      await expect(page.getByRole('heading', { name: /^Budget/ })).toBeVisible()
+      await page.goto('/finance-tracking/#/taxes')
+      await expect(page.getByRole('heading', { name: 'Taxes' })).toBeVisible()
+
+      expect(consoleErrors).toEqual([])
+    })
+
+    test('15. Import JSON with unknown keys ignores extras and imports known keys', async ({ page }) => {
+      // (was #60 test 32) — unknownField + futureFeature must NOT appear
+      // anywhere in localStorage (verify by enumerating keys), and the
+      // known goal must land in financialGoals.
+      const consoleErrors: string[] = []
+      page.on('pageerror', e => consoleErrors.push(e.message))
+
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('advanced')
+
+      const v2 = buildV2ImportWithUnknown()
+      await settings.importFileInput.setInputFiles({
+        name: v2.name,
+        mimeType: 'application/json',
+        buffer: Buffer.from(v2.content),
+      })
+
+      // Known goal made it through.
+      await expect
+        .poll(() => page.evaluate(() => localStorage.getItem('financialGoals')), { timeout: 10_000 })
+        .toContain('V2 Imported Goal')
+      await page.waitForLoadState('domcontentloaded')
+
+      // Anti-leak: neither unknown key name appears as a localStorage key.
+      const keys = await page.evaluate(() => Object.keys(localStorage))
+      expect(keys).not.toContain('unknownField')
+      expect(keys).not.toContain('futureFeature')
+
+      // Anti-leak: neither unknown value substring leaked into any stored value.
+      const allValues = await page.evaluate(() =>
+        Object.keys(localStorage)
+          .map(k => localStorage.getItem(k))
+          .join('|'),
+      )
+      expect(allValues).not.toContain('"unknownField"')
+      expect(allValues).not.toContain('"futureFeature"')
+
+      expect(consoleErrors).toEqual([])
+    })
+  })
+
+  /* ── Persistence ──────────────────────────────────────────────── */
+
+  test.describe('Persistence', () => {
+    test('16. Accent theme persists across reload and applies CSS custom properties', async ({ page }) => {
+      // (was #60 test 33) — AppearancePane does NOT expose an accent
+      // picker (it only has Light/Dark buttons). The accent-theme contract
+      // is therefore: `accentTheme` in localStorage survives reload, AND
+      // the `--accent` CSS custom property on document.documentElement is
+      // a defined non-empty color. The colorThemes.css source only ships
+      // the "blue" palette (--accent: #3b82f6) at the moment; this test
+      // pins both halves of the contract so a future accent picker change
+      // OR a colorThemes refactor will trip the assertion.
+      await page.addInitScript(() => {
+        localStorage.clear()
+        localStorage.setItem('encryption-enabled', '0')
+        localStorage.setItem('onboarding-dismissed', '1')
+        localStorage.setItem('accentTheme', 'blue')
+      })
+      await page.goto('/finance-tracking/')
+      await page.waitForLoadState('domcontentloaded')
+
+      // Persistence half.
+      expect(await page.evaluate(() => localStorage.getItem('accentTheme'))).toBe('blue')
+
+      // Reload survives.
+      await page.reload()
+      expect(await page.evaluate(() => localStorage.getItem('accentTheme'))).toBe('blue')
+
+      // CSS custom property is applied and matches the blue palette
+      // shipped in src/styles/colorThemes.css (:root).
+      const accent = await page.evaluate(() =>
+        getComputedStyle(document.documentElement).getPropertyValue('--accent').trim().toLowerCase(),
+      )
+      expect(accent).toBe('#3b82f6')
+    })
+
+    test('17. `allowCsvImport` setting persists and controls upload visibility', async ({ page }) => {
+      // (was #60 test 34) — SPEC ADAPTATION: the spec says "navigate to
+      // Budget page" but `allowCsvImport` actually gates the Net Worth
+      // (Data) page's CSV controls (see src/pages/data/Data.tsx). Budget
+      // always exposes its Import CSV button regardless of this flag.
+      // Tests assert real behavior: navigate to /net-worth and verify the
+      // "Import from CSV" header button toggles in lockstep with the flag.
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('advanced')
+
+      // Flip ON.
+      await settings.allowCsvToggle.click()
+      await expect(settings.allowCsvToggle).toHaveAttribute('aria-checked', 'true')
+      await expect.poll(() => page.evaluate(() => localStorage.getItem('allowCsvImport'))).toBe('1')
+
+      // Reload + visit Net Worth: Import button is visible (header + empty-state both render).
+      await page.reload()
+      await page.goto('/finance-tracking/#/net-worth')
+      const importBtn = page.getByRole('button', { name: 'Import from CSV' })
+      await expect(importBtn.first()).toBeVisible()
+      expect(await importBtn.count()).toBeGreaterThan(0)
+
+      // Flip OFF via settings.
+      await settings.openInPlace()
+      await settings.navTo('advanced')
+      await expect(settings.allowCsvToggle).toHaveAttribute('aria-checked', 'true')
+      await settings.allowCsvToggle.click()
+      await expect(settings.allowCsvToggle).toHaveAttribute('aria-checked', 'false')
+      await expect.poll(() => page.evaluate(() => localStorage.getItem('allowCsvImport'))).toBe('0')
+      await settings.closeButton.click()
+
+      // Net Worth no longer renders the Import button.
+      await page.goto('/finance-tracking/#/net-worth')
+      await expect(page.getByRole('button', { name: 'Import from CSV' })).toHaveCount(0)
+    })
+
+    test('18. Labs toggle dispatches `labs-changed` event and updates feature visibility', async ({ page }) => {
+      // (was #60 test 35) — register the listener BEFORE the toggle action,
+      // then read the flag AFTER. Verify all three: event fired AND
+      // localStorage updated AND toggle visibility (aria-checked) flipped.
+      await seedEmpty(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('labs')
+
+      await page.evaluate(() => {
+        ;(window as unknown as { __labsFired: boolean }).__labsFired = false
+        window.addEventListener('labs-changed', () => {
+          ;(window as unknown as { __labsFired: boolean }).__labsFired = true
+        })
+      })
+
+      // Toggle the PDF→CSV lab. Pre: off.
+      await expect(settings.labPdfToCsvToggle).toHaveAttribute('aria-checked', 'false')
+      await settings.labPdfToCsvToggle.click()
+
+      // (1) Event fired.
+      await expect
+        .poll(() => page.evaluate(() => (window as unknown as { __labsFired: boolean }).__labsFired))
+        .toBe(true)
+      // (2) localStorage updated.
+      await expect.poll(() => page.evaluate(() => localStorage.getItem('lab-pdf-to-csv'))).toBe('1')
+      // (3) UI state reflects the change.
+      await expect(settings.labPdfToCsvToggle).toHaveAttribute('aria-checked', 'true')
+    })
+  })
+
+  /* ── Layout & Export ──────────────────────────────────────────── */
+
+  test.describe('Layout & Export', () => {
+    test('19. Profile with extremely long name does not break layout', async ({ page }) => {
+      // (was #60 test 38) — 200-char name must not introduce horizontal
+      // overflow. The contract is scrollWidth <= clientWidth on <html>;
+      // visual presence is implied but not the assertion target.
+      await seedProfile(page, { name: 'Short', birthday: '1988-02-10' })
+      const settings = new SettingsPage(page)
+      await settings.open()
+
+      const longName = 'A'.repeat(200)
+      await settings.editProfileBtn.click()
+      await settings.profileNameInput.fill(longName)
+      await settings.saveProfileBtn.click()
+      await expect(settings.profileSavedFlash).toBeVisible()
+
+      // Verify the long name is actually in storage (sanity check on save).
+      const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('user-profile') || '{}'))
+      expect(stored.name).toBe(longName)
+
+      // No horizontal scrollbar on <html> while modal is open.
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+          ),
+        )
+        .toBe(true)
+
+      // Close the modal and check Home greeting also doesn't overflow.
+      await settings.closeButton.click()
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+          ),
+        )
+        .toBe(true)
+    })
+
+    test('20. Export includes all v2 format keys when all data types are seeded', async ({ page }) => {
+      // (was #60 test 39) — capture the download via Playwright's
+      // download API (NOT blob-URL interception), parse it, and verify
+      // every one of the 15 v2 top-level keys is present with a non-null
+      // value, plus version === 2.
+      await seedAllData(page)
+      const settings = new SettingsPage(page)
+      await settings.open()
+      await settings.navTo('advanced')
+
+      const [download] = await Promise.all([
+        page.waitForEvent('download'),
+        settings.exportBtn.click(),
+      ])
+
+      // Read the streamed file body into a string and JSON.parse it.
+      const stream = await download.createReadStream()
+      const chunks: Buffer[] = []
+      for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      }
+      const text = Buffer.concat(chunks).toString('utf-8')
+      const exported = JSON.parse(text) as Record<string, unknown>
+
+      // version is exactly 2.
+      expect(exported.version).toBe(2)
+
+      // Per-key presence + non-null assertion (each gets its own failure message).
+      for (const key of V2_EXPORT_KEYS) {
+        expect(exported, `v2 export must contain top-level key "${key}"`).toHaveProperty(key)
+        expect(
+          exported[key],
+          `v2 export key "${key}" must not be null`,
+        ).not.toBeNull()
+        expect(
+          exported[key],
+          `v2 export key "${key}" must not be undefined`,
+        ).not.toBeUndefined()
+      }
+
+      // Spot-check seeded values flowed through (catches accidental
+      // value-stripping in the export pipeline).
+      const goals = exported.goals as Array<{ id: number; goalName: string }>
+      expect(goals[0]?.id).toBe(ALL_DATA_GOAL.id)
+      expect(goals[0]?.goalName).toBe(ALL_DATA_GOAL.goalName)
+      const balances = exported.dataBalances as Array<{ balance: number }>
+      expect(balances[0]?.balance).toBe(ALL_DATA_BALANCE.balance)
+    })
+  })
+})

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -216,7 +216,13 @@ test.describe('Settings — Non-Security E2E', () => {
       // app's context provider re-initialised it on cold load, holds an
       // empty container ([] / {} / null-serialized) — never the original
       // seeded payload. Per-key failure messages name the offender.
-      const EMPTY_REINIT_VALUES = new Set(['[]', '{}', 'null', ''])
+      // EMPTY_REINIT_VALUES — values that count as "cleared" because providers
+      // re-emit these as their default empty state on cold load (factory reset
+      // → reload). The empty string '' is intentionally NOT admitted: no
+      // current provider serialises cleared state as "" (verified by grep
+      // across src/), and excluding it makes the test fail loudly if a future
+      // regression introduces that shape.
+      const EMPTY_REINIT_VALUES = new Set(['[]', '{}', 'null'])
       for (const key of SENSITIVE_KEYS) {
         const value = await page.evaluate(k => localStorage.getItem(k), key)
         if (value === null) continue
@@ -369,6 +375,12 @@ test.describe('Settings — Non-Security E2E', () => {
       // Ensure the post-import reload has settled before we navigate.
       await page.waitForLoadState('domcontentloaded')
 
+      // Goals page renders the imported goal — guards against a regression
+      // where the validator accepts the payload but the Goals page filters
+      // it out (LS substring check alone would miss that).
+      await page.goto('/finance-tracking/#/goal')
+      await expect(page.getByText('FI Goal')).toBeVisible()
+
       // Net Worth, Budget, Taxes each render their empty states with no
       // console errors. We visit each route directly.
       await page.goto('/finance-tracking/#/net-worth')
@@ -419,6 +431,13 @@ test.describe('Settings — Non-Security E2E', () => {
       )
       expect(allValues).not.toContain('"unknownField"')
       expect(allValues).not.toContain('"futureFeature"')
+
+      // Goals page renders the imported known goal — guards against a
+      // regression where unknown-key stripping inadvertently drops the
+      // known payload too, or where the validator accepts it but the
+      // Goals page filters it out at render time.
+      await page.goto('/finance-tracking/#/goal')
+      await expect(page.getByText('V2 Imported Goal')).toBeVisible()
 
       expect(consoleErrors).toEqual([])
     })
@@ -482,7 +501,6 @@ test.describe('Settings — Non-Security E2E', () => {
       await page.goto('/finance-tracking/#/net-worth')
       const importBtn = page.getByRole('button', { name: 'Import from CSV' })
       await expect(importBtn.first()).toBeVisible()
-      expect(await importBtn.count()).toBeGreaterThan(0)
 
       // Flip OFF via settings.
       await settings.openInPlace()

--- a/src/pages/settings/SettingsModal.test.tsx
+++ b/src/pages/settings/SettingsModal.test.tsx
@@ -128,6 +128,29 @@ describe('SettingsModal tab navigation', () => {
     expect(screen.getByTestId('appearance-pane')).toBeInTheDocument()
     expect(screen.queryByTestId('profile-pane')).not.toBeInTheDocument()
   })
+
+  // E2E load-bearing: e2e/settings.spec.ts asserts the active nav item via
+  // aria-current="page" rather than the brittle .active class. If this
+  // attribute disappears, settings test 12 will silently start passing on
+  // the wrong nav item.
+  it('marks only the active nav item with aria-current="page"', async () => {
+    const user = userEvent.setup()
+    render(<SettingsModal {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /profile/i })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('button', { name: /appearance/i })).not.toHaveAttribute('aria-current')
+    await user.click(screen.getByRole('button', { name: /appearance/i }))
+    expect(screen.getByRole('button', { name: /appearance/i })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('button', { name: /profile/i })).not.toHaveAttribute('aria-current')
+  })
+
+  // E2E load-bearing: dialog must be queryable by its accessible name
+  // ("Settings") via aria-labelledby pointing at the H2 title.
+  it('exposes the dialog with accessible name "Settings" via aria-labelledby', () => {
+    render(<SettingsModal {...defaultProps} />)
+    const dialog = screen.getByRole('dialog', { name: 'Settings' })
+    expect(dialog).toHaveAttribute('aria-labelledby', 'settings-modal-title')
+    expect(document.getElementById('settings-modal-title')).toHaveTextContent('Settings')
+  })
 })
 
 /* ── Close behavior ──────────────────────────────────────────── */

--- a/src/pages/settings/SettingsModal.tsx
+++ b/src/pages/settings/SettingsModal.tsx
@@ -44,9 +44,18 @@ const SettingsModal: FC<SettingsModalProps> = props => {
 
   return createPortal(
     <div className="settings-modal-backdrop" onClick={onClose}>
-      <div ref={modalRef} className="settings-modal" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true">
+      <div
+        ref={modalRef}
+        className="settings-modal"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-modal-title"
+      >
         <div className="settings-modal-header">
-          <h2 className="settings-modal-title">Settings</h2>
+          <h2 className="settings-modal-title" id="settings-modal-title">
+            Settings
+          </h2>
           <button className="settings-modal-close" onClick={onClose} aria-label="Close">
             <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
               <path d="M2 2L14 14M14 2L2 14" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
@@ -58,6 +67,7 @@ const SettingsModal: FC<SettingsModalProps> = props => {
           <nav className="settings-modal-nav">
             <button
               className={`settings-modal-nav-item${activeSection === 'profile' ? ' active' : ''}`}
+              aria-current={activeSection === 'profile' ? 'page' : undefined}
               onClick={() => setActiveSection('profile')}
             >
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -68,6 +78,7 @@ const SettingsModal: FC<SettingsModalProps> = props => {
             </button>
             <button
               className={`settings-modal-nav-item${activeSection === 'github' ? ' active' : ''}`}
+              aria-current={activeSection === 'github' ? 'page' : undefined}
               onClick={() => setActiveSection('github')}
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -78,6 +89,7 @@ const SettingsModal: FC<SettingsModalProps> = props => {
             </button>
             <button
               className={`settings-modal-nav-item${activeSection === 'appearance' ? ' active' : ''}`}
+              aria-current={activeSection === 'appearance' ? 'page' : undefined}
               onClick={() => setActiveSection('appearance')}
             >
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -100,6 +112,7 @@ const SettingsModal: FC<SettingsModalProps> = props => {
             </button>
             <button
               className={`settings-modal-nav-item${activeSection === 'security' ? ' active' : ''}`}
+              aria-current={activeSection === 'security' ? 'page' : undefined}
               onClick={() => setActiveSection('security')}
             >
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -109,6 +122,7 @@ const SettingsModal: FC<SettingsModalProps> = props => {
             </button>
             <button
               className={`settings-modal-nav-item${activeSection === 'advanced' ? ' active' : ''}`}
+              aria-current={activeSection === 'advanced' ? 'page' : undefined}
               onClick={() => setActiveSection('advanced')}
             >
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -118,6 +132,7 @@ const SettingsModal: FC<SettingsModalProps> = props => {
             </button>
             <button
               className={`settings-modal-nav-item${activeSection === 'labs' ? ' active' : ''}`}
+              aria-current={activeSection === 'labs' ? 'page' : undefined}
               onClick={() => setActiveSection('labs')}
             >
               <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -128,6 +143,7 @@ const SettingsModal: FC<SettingsModalProps> = props => {
             {isAdmin && (
               <button
                 className={`settings-modal-nav-item${activeSection === 'flags' ? ' active' : ''}`}
+                aria-current={activeSection === 'flags' ? 'page' : undefined}
                 onClick={() => setActiveSection('flags')}
               >
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">


### PR DESCRIPTION
Closes #128

Third and final sub-issue of #60 — Settings, Import/Export, and Modal shell E2E coverage. 20 tests across Profile, Appearance, Advanced, Labs, Modal, Import/Export.

## Commits

| SHA | Summary |
|---|---|
| `c2b2b3e` | Initial implementation — 20 tests, page object, fixtures, +2 unit guards for new ARIA on SettingsModal |
| `4b07ce2` | Fix pass — Goals page UI assertions on import tests, hygiene |

## Review history

| Round | Alex | Casey |
|---|---|---|
| R1 (`c2b2b3e`) | 🟡 SHIP WITH FIXES | 🟡 SHIP WITH FIXES |
| R2 (`4b07ce2`) | ✅ SHIP | ✅ SHIP |

## Spec adaptations (4)

1. **Test 8 factory reset** — `null OR empty container` accommodates providers that re-emit defaults on cold load after `localStorage.clear() + reload`.
2. **Test 14 v1 import** — `importValidator.ts` requires numeric `id` + non-empty `goalName`. Spec's literal `{id:'g1', name:'FI Goal'}` would have been rejected. Adapted to validator-compliant shape that surfaces the goal.
3. **Test 16 accent** — `AppearancePane` ships only Light/Dark buttons; no accent picker exists. Reduced to static contract pin on `--accent` CSS var. Picker UI deferred to #139.
4. **Test 17 allowCsvImport** — Flag is consumed in `src/pages/data/Data.tsx` (Net Worth Import), not `Budget.tsx` which renders "Import CSV" unconditionally. Test gates on `/net-worth` route.

## Source changes (a11y only)

- `SettingsModal.tsx` — `aria-current="page"` on 7 nav buttons + `aria-labelledby` on dialog
- `SettingsModal.test.tsx` — +2 unit guards pinning both ARIA attributes

## Verification

- 20/20 settings E2E × 3 consecutive runs
- 242/243 full E2E (sole flake at `home.spec.ts:484`, filed #138 — unrelated)
- 2687/2687 unit
- Anti-pattern grep zero matches on all 5 patterns

## Follow-ups filed

- **#138** — `home.spec.ts:484` arrow-key search nav flake
- **#139** — Settings tablist semantics + accent picker + theme button aria-labels + DataPage extraction

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
