### PR TITLE
test(e2e): Sidebar navigation, routing, and active state (#141)

### DIFF
--- a/e2e/fixtures/nav-data.ts
+++ b/e2e/fixtures/nav-data.ts
@@ -38,12 +38,31 @@ export function hashUrl(path: string): string {
  * Seed minimal localStorage state so the app mounts without onboarding
  * or unlock screens. Uses `addInitScript` so it runs before app code on
  * every navigation (including reloads triggered inside the test).
+ *
+ * Also intercepts the public feature-flags fetch (`FlagContext` calls
+ * `https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json`
+ * on every mount). Without this mock the live GitHub API rate-limits
+ * anonymous requests and returns 403, producing a console error that
+ * leaks into console-error assertions (e.g., navigation.spec.ts test 13).
+ * Lifting this to a global Playwright before-each is tracked separately.
  */
 export async function seedNav(page: Page, options: NavSeedOptions = {}): Promise<void> {
   const { profileName, extra } = options
   const profile = profileName
     ? JSON.stringify({ name: profileName, birthday: '', avatarDataUrl: '', partner: null })
     : null
+  await page.route(
+    'https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json',
+    async (route) => {
+      const emptyConfig = { flags: {} }
+      const content = Buffer.from(JSON.stringify(emptyConfig)).toString('base64')
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content, encoding: 'base64' }),
+      })
+    },
+  )
   await page.addInitScript(
     ({ profile, extra }) => {
       localStorage.clear()

--- a/e2e/fixtures/nav-data.ts
+++ b/e2e/fixtures/nav-data.ts
@@ -1,0 +1,81 @@
+import { Page } from '@playwright/test'
+
+/**
+ * Seed helpers for the navigation E2E suites (#141 / 61a–d).
+ *
+ * The navigation tests do not need rich domain data — they only need
+ * each page (Home, Goals, Net Worth, Budget, Taxes, Drive) to mount its
+ * top-level layout (h1 + main content) without console errors. Each
+ * page renders its h1 unconditionally, so `seedNav` only has to:
+ *
+ *   1. clear localStorage (so prior tests don't bleed in),
+ *   2. disable encryption (avoid the UnlockScreen),
+ *   3. dismiss the Home onboarding card so its hero h1 is the first
+ *      heading on the page.
+ *
+ * Sub-issues 61b (search), 61c (mobile), and 61d (keyboard) extend the
+ * same seed surface. Add only navigation-shared keys here. Page-specific
+ * fixtures belong in their own files.
+ */
+
+export interface NavSeedOptions {
+  /** Optional profile name to personalize the Home greeting. */
+  profileName?: string
+  /** Set viewport-affecting flags. Reserved for 61c (mobile). */
+  extra?: Record<string, string>
+}
+
+/** App base path under Vite dev server. */
+export const APP_BASE = '/finance-tracking/'
+
+/** Build a hash-router URL: `hashUrl('/goal')` → `/finance-tracking/#/goal`. */
+export function hashUrl(path: string): string {
+  const clean = path.startsWith('/') ? path : `/${path}`
+  return `${APP_BASE}#${clean}`
+}
+
+/**
+ * Seed minimal localStorage state so the app mounts without onboarding
+ * or unlock screens. Uses `addInitScript` so it runs before app code on
+ * every navigation (including reloads triggered inside the test).
+ */
+export async function seedNav(page: Page, options: NavSeedOptions = {}): Promise<void> {
+  const { profileName, extra } = options
+  const profile = profileName
+    ? JSON.stringify({ name: profileName, birthday: '', avatarDataUrl: '', partner: null })
+    : null
+  await page.addInitScript(
+    ({ profile, extra }) => {
+      localStorage.clear()
+      localStorage.setItem('encryption-enabled', '0')
+      localStorage.setItem('onboarding-dismissed', '1')
+      if (profile) localStorage.setItem('user-profile', profile)
+      if (extra) for (const [k, v] of Object.entries(extra)) localStorage.setItem(k, v)
+    },
+    { profile, extra: extra ?? null },
+  )
+}
+
+/** The ordered list of sidebar nav buttons covered by 61a. */
+export const PRIMARY_NAV_LINKS = ['Home', 'Goals', 'Net Worth', 'Budget', 'Taxes'] as const
+export type PrimaryNavLink = (typeof PRIMARY_NAV_LINKS)[number]
+
+/** Hash path each nav link routes to. */
+export const NAV_PATHS: Record<PrimaryNavLink | 'Drive', string> = {
+  Home: '/',
+  Goals: '/goal',
+  'Net Worth': '/net-worth',
+  Budget: '/budget',
+  Taxes: '/taxes',
+  Drive: '/drive',
+}
+
+/** The h1 text rendered on each route (regex tolerates the dynamic Home greeting). */
+export const PAGE_HEADINGS: Record<PrimaryNavLink | 'Drive', RegExp> = {
+  Home: /^Good (morning|afternoon|evening)/,
+  Goals: /^Goals$/,
+  'Net Worth': /^Net Worth$/,
+  Budget: /^Budget$/,
+  Taxes: /^Taxes$/,
+  Drive: /^Drive$/,
+}

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -65,10 +65,11 @@ test.describe('Sidebar navigation, routing, and active state (#141)', () => {
     await nav.navTo('Taxes')
     await nav.expectActive('Taxes')
 
-    // Spec 5 (enhanced): the sidebar toggle must expose an accessible name.
-    // Source: SidebarToggle.tsx renders aria-label="Collapse sidebar" while
-    // the sidebar is open.
-    await expect(nav.toggleCollapse).toHaveAttribute('aria-label', 'Collapse sidebar')
+    // Spec 5 (enhanced): the sidebar toggle's accessible name must flip
+    // when the sidebar collapses. Asserting toggleExpand becomes visible
+    // confirms the same physical toggle now reads "Expand sidebar".
+    await nav.collapseSidebar()
+    await expect(nav.toggleExpand).toBeVisible()
   })
 
   test('6. Drive button in footer navigates to /drive and marks it active', async ({ page }) => {
@@ -95,6 +96,7 @@ test.describe('Sidebar navigation, routing, and active state (#141)', () => {
     for (const name of PRIMARY_NAV_LINKS) {
       await expect(nav.link(name)).toBeHidden()
     }
+    await expect(nav.link('Drive')).toBeHidden()
     await expect(nav.toggleExpand).toBeVisible()
   })
 
@@ -224,8 +226,6 @@ test.describe('Sidebar navigation, routing, and active state (#141)', () => {
   })
 
   test('38. a non-existent route falls back to Home with Home marked active', async ({ page }) => {
-    // Same wildcard fallback as test 15, asserted via the back-door entry
-    // (direct URL goto rather than in-app navigation).
     const nav = new NavigationPage(page)
     await nav.goto('/this-route-does-not-exist')
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,255 @@
+import { test, expect, ConsoleMessage } from '@playwright/test'
+import { NavigationPage, routeRegex } from './pages/navigation.page'
+import { hashUrl, NAV_PATHS, PAGE_HEADINGS, PRIMARY_NAV_LINKS, seedNav } from './fixtures/nav-data'
+
+/**
+ * Sub-issue #141 (61a of 4 under #61) — Sidebar navigation, routing,
+ * active state. 17 tests covering link presence, route navigation,
+ * `aria-current="page"`, no-console-error smoke, rapid navigation,
+ * browser refresh, invalid route fallback, and hash fragment behavior.
+ *
+ * The app uses HashRouter (see src/main.tsx) under the Vite base
+ * `/finance-tracking/`. URLs are matched against the trailing `#/<path>`.
+ * Invalid routes are caught by `<Route path="*" element={<Navigate to="/"
+ * replace />} />` in App.tsx — there is no 404 component.
+ */
+
+test.describe('Sidebar navigation, routing, and active state (#141)', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedNav(page)
+  })
+
+  /* ── Sidebar link presence ──────────────────────────────────── */
+
+  test('1. sidebar shows all primary navigation links and Home is active by default', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+
+    await expect(nav.sidebar).toBeVisible()
+    for (const name of PRIMARY_NAV_LINKS) {
+      await expect(nav.link(name)).toBeVisible()
+    }
+    // Drive lives in the footer Utilities group, not the primary list.
+    await expect(nav.link('Drive')).toBeVisible()
+
+    // Home is the default route → only Home carries aria-current="page".
+    await nav.expectActive('Home')
+  })
+
+  /* ── Per-link navigation ────────────────────────────────────── */
+
+  test('2. clicking "Goals" navigates to /goal and marks it active', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+    await nav.navTo('Goals')
+    await nav.expectActive('Goals')
+  })
+
+  test('3. clicking "Net Worth" navigates to /net-worth and marks it active', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+    await nav.navTo('Net Worth')
+    await nav.expectActive('Net Worth')
+  })
+
+  test('4. clicking "Budget" navigates to /budget and marks it active', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+    await nav.navTo('Budget')
+    await nav.expectActive('Budget')
+  })
+
+  test('5. clicking "Taxes" navigates to /taxes and the toggle has an aria-label', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+    await nav.navTo('Taxes')
+    await nav.expectActive('Taxes')
+
+    // Spec 5 (enhanced): the sidebar toggle must expose an accessible name.
+    // Source: SidebarToggle.tsx renders aria-label="Collapse sidebar" while
+    // the sidebar is open.
+    await expect(nav.toggleCollapse).toHaveAttribute('aria-label', 'Collapse sidebar')
+  })
+
+  test('6. Drive button in footer navigates to /drive and marks it active', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+    await nav.navTo('Drive')
+    await nav.expectActive('Drive')
+  })
+
+  /* ── Sidebar collapse / expand ─────────────────────────────── */
+
+  test('7. collapsing the sidebar removes the nav links and shows only the expand toggle', async ({ page }) => {
+    // Adaptation: AppShell unmounts <SidebarNavigation /> when sidebarOpen
+    // is false (App.tsx:131), so the sidebar nav region is *removed* from
+    // the DOM rather than just receiving a `collapsed` class. The user-
+    // visible contract — nav links are gone, the expand toggle is the
+    // only thing left — still holds, which is what we assert.
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+
+    await nav.collapseSidebar()
+
+    await expect(nav.sidebar).toBeHidden()
+    for (const name of PRIMARY_NAV_LINKS) {
+      await expect(nav.link(name)).toBeHidden()
+    }
+    await expect(nav.toggleExpand).toBeVisible()
+  })
+
+  test('8. expanding the sidebar after collapse restores all nav links', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+
+    await nav.collapseSidebar()
+    await nav.expandSidebar()
+
+    await expect(nav.sidebar).toBeVisible()
+    for (const name of PRIMARY_NAV_LINKS) {
+      await expect(nav.link(name)).toBeVisible()
+    }
+    await expect(nav.link('Drive')).toBeVisible()
+  })
+
+  /* ── Page load smoke ───────────────────────────────────────── */
+
+  test('13. every primary route loads without console or page errors', async ({ page }) => {
+    // Mirrors the taxes.spec.ts pattern (pageerror) and additionally
+    // collects console errors, filtering noise that is not a regression
+    // signal (React DevTools nag in dev, Vite HMR transport, source-map
+    // 404s for lazy chunks).
+    const pageErrors: string[] = []
+    const consoleErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(e.message))
+    page.on('console', (msg: ConsoleMessage) => {
+      if (msg.type() !== 'error') return
+      const text = msg.text()
+      if (/React DevTools|\[vite\]|source ?map/i.test(text)) return
+      consoleErrors.push(text)
+    })
+
+    const nav = new NavigationPage(page)
+    for (const name of [...PRIMARY_NAV_LINKS, 'Drive'] as const) {
+      await nav.goto(NAV_PATHS[name])
+      await expect(page.getByRole('heading', { level: 1, name: PAGE_HEADINGS[name] })).toBeVisible()
+    }
+
+    expect(pageErrors).toEqual([])
+    expect(consoleErrors).toEqual([])
+  })
+
+  test('14. direct URL access works for nested sub-routes', async ({ page }) => {
+    const nav = new NavigationPage(page)
+
+    await nav.goto('/net-worth/allocation')
+    await expect(page).toHaveURL(/#\/net-worth\/allocation$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'Net Worth' })).toBeVisible()
+    // The Net Worth section nav should mark Allocation as active.
+    await expect(page.getByRole('link', { name: 'Allocation' })).toHaveAttribute('aria-current', 'page')
+
+    await nav.goto('/goal/calculator')
+    await expect(page).toHaveURL(/#\/goal\/calculator$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'Goals' })).toBeVisible()
+
+    await nav.goto('/drive')
+    await expect(page).toHaveURL(/#\/drive$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'Drive' })).toBeVisible()
+  })
+
+  test('15. navigating to an unknown route redirects to Home', async ({ page }) => {
+    // App.tsx defines `<Route path="*" element={<Navigate to="/" replace />} />`.
+    // That is the canonical "not found" behavior — no 404 component exists.
+    const nav = new NavigationPage(page)
+    await nav.goto('/nonexistent-page')
+
+    await expect(page).toHaveURL(routeRegex('/'))
+    await expect(page.getByRole('heading', { level: 1, name: PAGE_HEADINGS['Home'] })).toBeVisible()
+    await nav.expectActive('Home')
+  })
+
+  /* ── Active state guarantees ───────────────────────────────── */
+
+  test('24. the active page link has aria-current="page" and the visual active class', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+    await nav.navTo('Budget')
+
+    const budget = nav.link('Budget')
+    await expect(budget).toHaveAttribute('aria-current', 'page')
+    // Visual indicator uses the `active` className suffix on .sidebar-link.
+    // This is a defense-in-depth check: aria-current is the contract,
+    // class `active` is the styling hook. Both must move together.
+    await expect(budget).toHaveClass(/(?:^|\s)sidebar-link active(?:$|\s)/)
+  })
+
+  test('25. exactly one nav link is active at any time after navigating between pages', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+
+    for (const name of ['Goals', 'Net Worth', 'Budget', 'Taxes', 'Home'] as const) {
+      await nav.navTo(name)
+      await nav.expectActive(name)
+    }
+  })
+
+  /* ── Edge cases ────────────────────────────────────────────── */
+
+  test('26. rapid navigation between pages leaves the final page in a consistent state', async ({ page }) => {
+    // Click Home → Goals → Net Worth → Budget in quick succession. Only
+    // the final state is asserted — intermediate URLs are a race.
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+
+    await nav.link('Goals').click()
+    await nav.link('Net Worth').click()
+    await nav.link('Budget').click()
+
+    await expect(page).toHaveURL(routeRegex('/budget'))
+    await expect(page.getByRole('heading', { level: 1, name: 'Budget' })).toBeVisible()
+    await nav.expectActive('Budget')
+  })
+
+  test('27. browser refresh on a sub-route preserves the page and active link', async ({ page }) => {
+    const nav = new NavigationPage(page)
+    await nav.goto('/')
+    await nav.navTo('Goals')
+
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect(page).toHaveURL(routeRegex('/goal'))
+    await expect(page.getByRole('heading', { level: 1, name: 'Goals' })).toBeVisible()
+    await nav.expectActive('Goals')
+  })
+
+  test('38. a non-existent route falls back to Home with Home marked active', async ({ page }) => {
+    // Same wildcard fallback as test 15, asserted via the back-door entry
+    // (direct URL goto rather than in-app navigation).
+    const nav = new NavigationPage(page)
+    await nav.goto('/this-route-does-not-exist')
+
+    await expect(page).toHaveURL(routeRegex('/'))
+    await expect(page.getByRole('heading', { level: 1, name: PAGE_HEADINGS['Home'] })).toBeVisible()
+    await nav.expectActive('Home')
+  })
+
+  test('39. hash fragment with no matching anchor lands at top of Home without error', async ({ page }) => {
+    // Adaptation: the app uses HashRouter, which consumes the URL hash to
+    // resolve routes. A bare hash like `#goals-section` is interpreted as
+    // a route path `goals-section`, falls through to the wildcard, and
+    // redirects to `/`. In-page anchor scrolling via `#section-id` is
+    // therefore unsupported in this app. We capture the actual contract:
+    // no error, Home renders, viewport is at the top.
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(e.message))
+
+    await page.goto(`${hashUrl('/').replace('#/', '')}#goals-section`)
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect(page.getByRole('heading', { level: 1, name: PAGE_HEADINGS['Home'] })).toBeVisible()
+    const scrollY = await page.evaluate(() => window.scrollY)
+    expect(scrollY).toBe(0)
+    expect(pageErrors).toEqual([])
+  })
+})

--- a/e2e/pages/navigation.page.ts
+++ b/e2e/pages/navigation.page.ts
@@ -54,8 +54,7 @@ export class NavigationPage {
 
   /**
    * Assert exactly one nav link has `aria-current="page"`, and it is the
-   * one named `name`. Empty string asserts no link is active (used after
-   * intentional invalid-route navigation).
+   * one named `name`.
    */
   async expectActive(name: NavName): Promise<void> {
     await expect(this.link(name)).toHaveAttribute('aria-current', 'page')

--- a/e2e/pages/navigation.page.ts
+++ b/e2e/pages/navigation.page.ts
@@ -1,0 +1,98 @@
+import { Page, Locator, expect } from '@playwright/test'
+import { APP_BASE, hashUrl, NAV_PATHS, PAGE_HEADINGS, PrimaryNavLink } from '../fixtures/nav-data'
+
+export type NavName = PrimaryNavLink | 'Drive'
+
+/**
+ * Page object for the sidebar / primary-navigation flows (#141, 61a).
+ *
+ * All locators are accessible-name based. `aria-current="page"` is the
+ * canonical active-state assertion — never the `active` CSS class.
+ */
+export class NavigationPage {
+  readonly page: Page
+
+  readonly sidebar: Locator
+  readonly utilities: Locator
+  readonly toggleExpand: Locator
+  readonly toggleCollapse: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.sidebar = page.getByRole('navigation', { name: 'Main navigation' })
+    this.utilities = page.getByRole('group', { name: 'Utilities' })
+    // Two toggle buttons exist in the DOM (one inside the sidebar, one in
+    // the main-content rail when collapsed); their accessible names differ
+    // by state so each locator resolves to exactly one element at a time.
+    this.toggleCollapse = page.getByRole('button', { name: 'Collapse sidebar' })
+    this.toggleExpand = page.getByRole('button', { name: 'Expand sidebar' })
+  }
+
+  /** Navigate to the app root via the hash router. */
+  async goto(path: string = '/'): Promise<void> {
+    await this.page.goto(hashUrl(path))
+    await this.page.waitForLoadState('domcontentloaded')
+  }
+
+  /** Locator for a primary nav button. Drive lives in the footer group. */
+  link(name: NavName): Locator {
+    if (name === 'Drive') return this.utilities.getByRole('button', { name: 'Drive' })
+    return this.sidebar.getByRole('button', { name, exact: true })
+  }
+
+  /** Click a nav link and wait until URL + heading reflect the new page. */
+  async navTo(name: NavName): Promise<void> {
+    await this.link(name).click()
+    await this.expectOnPage(name)
+  }
+
+  /** Wait for the page to be on the route corresponding to `name`. */
+  async expectOnPage(name: NavName): Promise<void> {
+    await expect(this.page).toHaveURL(routeRegex(NAV_PATHS[name]))
+    await expect(this.page.getByRole('heading', { level: 1, name: PAGE_HEADINGS[name] })).toBeVisible()
+  }
+
+  /**
+   * Assert exactly one nav link has `aria-current="page"`, and it is the
+   * one named `name`. Empty string asserts no link is active (used after
+   * intentional invalid-route navigation).
+   */
+  async expectActive(name: NavName): Promise<void> {
+    await expect(this.link(name)).toHaveAttribute('aria-current', 'page')
+    for (const other of (['Home', 'Goals', 'Net Worth', 'Budget', 'Taxes', 'Drive'] as NavName[]).filter(
+      n => n !== name,
+    )) {
+      await expect(this.link(other)).not.toHaveAttribute('aria-current', /.*/)
+    }
+  }
+
+  /** Click the sidebar collapse button and wait for the sidebar to disappear. */
+  async collapseSidebar(): Promise<void> {
+    await this.toggleCollapse.click()
+    await expect(this.sidebar).toBeHidden()
+    await expect(this.toggleExpand).toBeVisible()
+  }
+
+  /** Click the expand button (visible only when sidebar is collapsed). */
+  async expandSidebar(): Promise<void> {
+    await this.toggleExpand.click()
+    await expect(this.sidebar).toBeVisible()
+    await expect(this.toggleCollapse).toBeVisible()
+  }
+}
+
+/**
+ * Build a regex that matches the trailing hash path. Uses end-of-string
+ * anchor so `/net-worth` does not match `/net-worth/allocation`.
+ */
+export function routeRegex(hashPath: string): RegExp {
+  const escaped = hashPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  // Home (`/`) is treated specially: HashRouter may render either
+  // `#/` or no hash at all after `Navigate to="/"`. Accept both.
+  if (hashPath === '/') return new RegExp(`${escapeForRegex(APP_BASE)}(?:#/?)?$`)
+  return new RegExp(`#${escaped}$`)
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}


### PR DESCRIPTION
Closes #141.

Sub-issue 61a of 4. Adds 17 Playwright tests covering sidebar nav presence, collapse/expand, active state (`aria-current="page"`), routing across all 6 primary surfaces, deep links, unknown routes, rapid nav, and reload persistence. All 17 × 3 consecutive: green. Full E2E 260/260. Unit 2687/2687.

## Review history

| Round | Reviewer | Verdict | Commit |
|---|---|---|---|
| 1 | Alex | 🟡 SHIP WITH FIXES | f8c1186 |
| 1 | Casey | 🟡 SHIP WITH FIXES | f8c1186 |
| fix | Quinn | — | 8b89e1b |
| fix | Quinn | — | 5474dd3 |
| 2 | Alex | ✅ SHIP | 5474dd3 |
| 2 | Casey | ✅ SHIP | 5474dd3 |

## Spec adaptations (all defensible per Alex)

- **Test 7** — `.collapsed` class doesn't exist. `App.tsx:131` unmounts `<SidebarNavigation/>` on collapse. Test asserts all primary links + Drive are hidden.
- **Tests 15/38** — `App.tsx:214` defines `<Route path="*" element={<Navigate to="/" replace />}>`. Tests assert redirect to Home + Home aria-current.
- **Test 39** — `main.tsx:11` uses HashRouter; `#goals-section` is consumed as a route segment, not an in-page anchor. Test captures the wildcard→Home fallback.
- **Test 13** — Console-error enumeration. `FlagContext` fetches `api.github.com` on every mount; anonymous rate-limit returned 403, leaking a browser-level failed-resource message. Fixed by route-mocking the feature-flags fetch in `seedNav` (see #146 for global lift).

## Files

- `e2e/navigation.spec.ts` (new, 17 tests)
- `e2e/pages/navigation.page.ts` (new, page object)
- `e2e/fixtures/nav-data.ts` (new, shared fixture — reused by 61b/c/d)

Zero source modifications.

## Follow-ups filed

- **#145** — Ellis: aria-current unit guards for Home/Net Worth/Budget/Taxes (only Goals + Drive are currently guarded).
- **#146** — Lift GitHub feature-flags route mock to global Playwright fixture so all suites are hermetic by default.
- **#138** — pre-existing home arrow-key search nav flake (unrelated).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>