### PR TITLE
test(e2e): SearchModal Cmd+K lifecycle and focus trap (8 tests, #142)

### DIFF
--- a/e2e/pages/search.page.ts
+++ b/e2e/pages/search.page.ts
@@ -1,0 +1,103 @@
+import { Page, Locator, expect } from '@playwright/test'
+import { hashUrl } from '../fixtures/nav-data'
+
+/**
+ * Page object for the Cmd+K SearchModal (#142, 61b).
+ *
+ * The global shortcut handler lives in `src/contexts/LayoutContext.tsx`
+ * and triggers on `(metaKey || ctrlKey) && key === 'k'`, so `Control+k`
+ * is cross-platform safe in Playwright (no need to branch on os).
+ *
+ * SearchModal renders into a portal at <body>, exposes `role="dialog"`
+ * with `aria-label="Search"`, a `role="combobox"` input, and rows with
+ * `role="option"` + `aria-selected` reflecting keyboard highlight.
+ */
+export class SearchPage {
+  readonly page: Page
+
+  readonly dialog: Locator
+  readonly input: Locator
+  readonly listbox: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.dialog = page.getByRole('dialog', { name: 'Search' })
+    this.input = this.dialog.getByRole('combobox')
+    this.listbox = this.dialog.getByRole('listbox', { name: 'Search results' })
+  }
+
+  /**
+   * Navigate to the app root via the hash router and wait for the React
+   * app to mount. The global Cmd+K listener is registered inside a
+   * LayoutContext `useEffect`, so pressing the shortcut before the
+   * sidebar appears is a race — waiting on the sidebar nav guarantees
+   * the listener is attached.
+   */
+  async goto(path: string = '/'): Promise<void> {
+    await this.page.goto(hashUrl(path))
+    await this.page.waitForLoadState('domcontentloaded')
+    await this.page.getByRole('navigation', { name: 'Main navigation' }).waitFor()
+  }
+
+  /**
+   * Open the modal via the global shortcut. Caller picks `Control+k` for
+   * hermetic cross-platform behavior; `Meta+k` is accepted by the source
+   * handler too (the predicate is `metaKey || ctrlKey`).
+   */
+  async openWithShortcut(key: 'Control+k' | 'Meta+k' = 'Control+k'): Promise<void> {
+    await this.page.keyboard.press(key)
+    await expect(this.dialog).toBeVisible()
+    // The input is focused via requestAnimationFrame inside SearchModal's
+    // open effect; toBeFocused waits for that frame to land.
+    await expect(this.input).toBeFocused()
+  }
+
+  /** All currently visible result rows (role="option"). */
+  results(): Locator {
+    return this.dialog.getByRole('option')
+  }
+
+  /**
+   * Result row by visible accessible name. The button's accessible name
+   * concatenates label + hint + category badge (e.g., "Budget Monthly
+   * spending Pages"), so we substring-match the label rather than
+   * requiring an exact accessible-name equality.
+   */
+  result(name: string | RegExp): Locator {
+    return this.dialog.getByRole('option', { name, exact: false })
+  }
+
+  /** The currently highlighted row (`aria-selected="true"`). */
+  activeResult(): Locator {
+    // role=option with selected:true narrows to the active row.
+    return this.dialog.getByRole('option', { selected: true })
+  }
+
+  async closeWithEscape(): Promise<void> {
+    await this.page.keyboard.press('Escape')
+    await expect(this.dialog).toBeHidden()
+  }
+
+  async arrowDown(times: number = 1): Promise<void> {
+    for (let i = 0; i < times; i++) {
+      await this.page.keyboard.press('ArrowDown')
+    }
+  }
+
+  async arrowUp(times: number = 1): Promise<void> {
+    for (let i = 0; i < times; i++) {
+      await this.page.keyboard.press('ArrowUp')
+    }
+  }
+
+  /**
+   * Returns true iff `document.activeElement` is a descendant of the
+   * search dialog. Used to verify the focus trap holds during Tab cycling.
+   */
+  async isFocusInsideDialog(): Promise<boolean> {
+    return await this.page.evaluate(() => {
+      const d = document.querySelector('[role="dialog"]')
+      return !!d && d.contains(document.activeElement)
+    })
+  }
+}

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,207 @@
+import { test, expect } from '@playwright/test'
+import { SearchPage } from './pages/search.page'
+import { seedNav } from './fixtures/nav-data'
+
+/**
+ * Sub-issue #142 (61b of 4 under #61) — SearchModal Cmd+K lifecycle and
+ * focus trap. 8 tests covering open via shortcut, query filtering, result
+ * selection + navigation, Escape close, dialog a11y attributes, keyboard
+ * arrow navigation, focus restoration on close, and Tab focus trap.
+ *
+ * The global shortcut handler in `src/contexts/LayoutContext.tsx` accepts
+ * either Meta+k or Control+k (`metaKey || ctrlKey`), so we use Control+k
+ * for cross-platform hermeticity. The dialog mounts via createPortal at
+ * <body> and the useFocusTrap hook saves `document.activeElement` on open
+ * and restores it on close — that contract is exercised by tests 30/32.
+ *
+ * Note on the "fi" query in test 29: against the empty (un-seeded)
+ * index, "fi" matches seven static items in this deterministic flat
+ * order (CATEGORY_ORDER then score/alpha within a group):
+ *   0. Drive (page, hint "Uploaded files" → "files" contains "fi")
+ *   1. Goals (page, hint "FI goal plans")
+ *   2. Open Profile (command, label contains "fi" in "profile", 60)
+ *   3. New Goal (command, hint "Create a new FI goal", 40)
+ *   4. Open Settings (command, keyword "config" contains "fi", 30)
+ *   5. FI Calculator (tool, label starts with "fi", 80)
+ *   6. Profile Settings (settings, label contains "fi")
+ * Multiple results let ArrowDown/ArrowUp actually move the active row
+ * (not clamp at index 0), so the increment/decrement/bounds logic is
+ * observable. The initial active index is 0; ArrowDown×5 → index 5,
+ * ArrowUp×1 → index 4, ArrowDown×1 → index 5 (FI Calculator →
+ * route `/goal/calculator`).
+ */
+
+test.describe('SearchModal — Cmd+K lifecycle and focus trap (#142)', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedNav(page)
+  })
+
+  /* ── Open & focus ───────────────────────────────────────────── */
+
+  test('9. Cmd+K opens search modal with input focused', async ({ page }) => {
+    const search = new SearchPage(page)
+    await search.goto('/')
+
+    await expect(search.dialog).toBeHidden()
+    await search.openWithShortcut('Control+k')
+
+    // openWithShortcut already asserts visible + input focused. Re-verify
+    // via document.activeElement to make the focus contract explicit at
+    // the test level rather than buried in the page object.
+    const isInputFocused = await search.input.evaluate(el => document.activeElement === el)
+    expect(isInputFocused).toBe(true)
+  })
+
+  /* ── Filtering ──────────────────────────────────────────────── */
+
+  test('10. typing in search modal filters results to matching items', async ({ page }) => {
+    const search = new SearchPage(page)
+    await search.goto('/')
+    await search.openWithShortcut('Control+k')
+
+    await search.input.fill('budget')
+
+    // Wait for at least one option to appear, then assert the Budget
+    // page row is among them. Label match scores higher than keywords,
+    // so the "Budget" page is guaranteed to be present.
+    await search.results().first().waitFor()
+    await expect(search.result('Budget')).toBeVisible()
+  })
+
+  /* ── Selection + navigation ─────────────────────────────────── */
+
+  test('11. selecting a search result closes the modal and navigates to that page', async ({ page }) => {
+    const search = new SearchPage(page)
+    await search.goto('/')
+    await search.openWithShortcut('Control+k')
+
+    await search.input.fill('net worth')
+    await search.results().first().waitFor()
+    await search.result('Net Worth').click()
+
+    await expect(search.dialog).toBeHidden()
+    await expect(page).toHaveURL(/#\/net-worth$/)
+    await expect(page.getByRole('heading', { level: 1, name: 'Net Worth' })).toBeVisible()
+  })
+
+  /* ── Escape close ───────────────────────────────────────────── */
+
+  test('12. Escape closes the search modal', async ({ page }) => {
+    const search = new SearchPage(page)
+    await search.goto('/')
+    await search.openWithShortcut('Control+k')
+
+    await search.closeWithEscape()
+  })
+
+  /* ── A11y contract ──────────────────────────────────────────── */
+
+  test('28. Cmd+K opens dialog with role="dialog", accessible name, and focused input', async ({ page }) => {
+    const search = new SearchPage(page)
+    await search.goto('/')
+
+    await page.keyboard.press('Control+k')
+
+    // role="dialog" with accessible name "Search" (aria-label on source).
+    const dialog = page.getByRole('dialog', { name: 'Search' })
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toHaveAttribute('aria-label', 'Search')
+    await expect(dialog).toHaveAttribute('aria-modal', 'true')
+
+    // Input is focused after the rAF inside the open effect.
+    await expect(search.input).toBeFocused()
+  })
+
+  /* ── ArrowDown / ArrowUp / Enter ───────────────────────────── */
+
+  test('29. ArrowDown/ArrowUp move highlight through results, Enter selects and navigates', async ({ page }) => {
+    // The initial active index is 0 (first row pre-selected). Sequence:
+    // ArrowDown×5 → index 5; ArrowUp×1 → index 4; ArrowDown×1 → index 5
+    // (FI Calculator → /goal/calculator).
+    const search = new SearchPage(page)
+    await search.goto('/')
+    await search.openWithShortcut('Control+k')
+
+    await search.input.fill('fi')
+    await search.results().first().waitFor()
+
+    const firstName = (await search.results().first().textContent())?.trim() ?? ''
+
+    await search.arrowDown(5)
+    await search.arrowUp(1)
+    await search.arrowDown(1)
+
+    const active = search.activeResult()
+    await expect(active).toBeVisible()
+    const activeName = (await active.textContent())?.trim() ?? ''
+    expect(activeName).toContain('FI Calculator')
+    expect(activeName).not.toBe(firstName)
+
+    await page.keyboard.press('Enter')
+
+    await expect(search.dialog).toBeHidden()
+    await expect(page).toHaveURL(/#\/goal\/calculator$/)
+  })
+
+  /* ── Focus restoration ─────────────────────────────────────── */
+
+  test('30. Escape closes the modal and restores focus to the previously focused element', async ({ page }) => {
+    const search = new SearchPage(page)
+    await search.goto('/')
+
+    // The sidebar renders nav items as <button>, not <a>. Focus the
+    // Goals button so useFocusTrap captures it as previousFocus on open.
+    const goalsBtn = page
+      .getByRole('navigation', { name: 'Main navigation' })
+      .getByRole('button', { name: 'Goals', exact: true })
+    await goalsBtn.focus()
+    await expect(goalsBtn).toBeFocused()
+
+    await page.keyboard.press('Control+k')
+    await expect(search.dialog).toBeVisible()
+    await expect(search.input).toBeFocused()
+
+    await page.keyboard.press('Escape')
+    await expect(search.dialog).toBeHidden()
+
+    await expect(goalsBtn).toBeFocused()
+  })
+
+  /* ── Tab focus trap + restoration ──────────────────────────── */
+
+  test('32. Tab cycles focus within the modal and Escape restores prior focus', async ({ page }) => {
+    const search = new SearchPage(page)
+    await search.goto('/')
+
+    // Pre-focus the Home button so we can verify focus restoration on
+    // close, per the second half of the spec for this test.
+    const homeBtn = page
+      .getByRole('navigation', { name: 'Main navigation' })
+      .getByRole('button', { name: 'Home', exact: true })
+    await homeBtn.focus()
+    await expect(homeBtn).toBeFocused()
+
+    await page.keyboard.press('Control+k')
+    await expect(search.dialog).toBeVisible()
+    await expect(search.input).toBeFocused()
+
+    // Tab repeatedly. The empty-query index renders 5 page rows + show-all
+    // + 5 command rows + show-all = 12 buttons, so 13 Tabs from the input
+    // wraps back to the input. Cycle 20 Tabs to confirm focus never
+    // escapes the dialog and that wrap returns to the input.
+    let wrappedToInput = false
+    for (let i = 0; i < 20; i++) {
+      await page.keyboard.press('Tab')
+      const inside = await search.isFocusInsideDialog()
+      expect(inside, `Tab #${i + 1} moved focus outside the dialog`).toBe(true)
+      const isInput = await search.input.evaluate(el => document.activeElement === el)
+      if (isInput && i > 0) wrappedToInput = true
+    }
+    expect(wrappedToInput, 'Tab cycle never returned focus to the search input').toBe(true)
+
+    await page.keyboard.press('Escape')
+    await expect(search.dialog).toBeHidden()
+
+    await expect(homeBtn).toBeFocused()
+  })
+})


### PR DESCRIPTION
Closes #142.

Sub-issue 61b of 4. Adds 8 Playwright tests covering SearchModal's Cmd+K (Control+k) lifecycle: open with shortcut, type-to-filter, keyboard navigation (Arrow keys + Enter), Escape close, click-to-select, focus trap, and focus restoration on close.

## Test runs

- 8/8 single, 24/24 ×3, 268/268 full E2E, 2687/2687 unit, all 5 anti-pattern greps clean.

## Review history

| Round | Reviewer | Verdict | Commit |
|---|---|---|---|
| 1 | Alex | 🟡 SHIP WITH FIXES | b95ede4 |
| 1 | Casey | 🟡 SHIP WITH FIXES | b95ede4 |
| fix | Quinn | — | 605c4a9 |
| 2 | Alex | ✅ SHIP | 605c4a9 |
| 2 | Casey | ✅ SHIP | 605c4a9 |

Round-1 finding (both reviewers): test 29's `"net"` query yielded 1 result, so ArrowDown/ArrowUp clamped at index 0 — the test passed even though arrow movement wasn't observable. Fixed by switching to `"fi"` (7 results, deterministic flat order), exercising ArrowDown×5 + ArrowUp×1 + ArrowDown×1 to land on FI Calculator (index 5), and adding a `firstName !== activeName` assertion to prove movement.

## Spec adaptations

- **Test 29 query:** `"fi"` chosen for deterministic multi-result coverage (7 matches across all 4 categories). Real flat order: Drive, Goals, Open Profile, New Goal, Open Settings, **FI Calculator**, Profile Settings. URL regex: `/#\/goal\/calculator$/`.
- **`result(name)` substring match:** result rows' accessible name concatenates label + hint + category badge.
- **`SearchPage.goto()`** waits for sidebar nav before any Cmd+K — closes a race where LayoutContext's keydown listener registers in a useEffect after mount.

## Files

- `e2e/search.spec.ts` (new, 8 tests)
- `e2e/pages/search.page.ts` (new, page object)

Zero source modifications. SearchModal already exposes `role="dialog"`, `aria-label="Search"`, `aria-modal="true"`, `role="combobox"` input, `role="listbox"` results, `role="option"` rows with `aria-selected`.

## Follow-ups

- **#146** — global GitHub feature-flags mock fixture (filed during #141).
- Deferred to 61c (mobile): `SearchPage.goto()` sidebar wait will need a viewport-agnostic anchor (e.g., `role="main"`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>