### PR TITLE
feat(e2e): #151 Home dashboard cross-page integration (62a)

### DIFF
--- a/e2e/cross-page-home.spec.ts
+++ b/e2e/cross-page-home.spec.ts
@@ -477,25 +477,20 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
         buffer: Buffer.from(v2.content),
       })
 
-      // Await the counter increment (C4 poll pattern). ImportExportContext
-      // dispatches `data-changed` synchronously inside the reader.onload
-      // (ImportExportContext.tsx:127) before scheduling reload at +200ms.
-      await expect
-        .poll(
-          () =>
-            page.evaluate(() => Number(localStorage.getItem('__test_data_changed_count') || '0')),
-          { timeout: 5000 },
-        )
-        .toBeGreaterThanOrEqual(1)
-
-      // Wait for the post-import reload to settle by polling
-      // localStorage for the imported accounts.
-      await expect
-        .poll(() => page.evaluate(() => localStorage.getItem('data-accounts')), { timeout: 10_000 })
-        .toContain('401k')
-      // C5: explicitly wait for the reload to finish before any further
-      // localStorage assertions (Heading-visible proves DataContext mounted).
-      await page.waitForLoadState('domcontentloaded')
+      // C5 (revised after CI flake): ImportExportContext dispatches
+      // `data-changed` synchronously inside reader.onload
+      // (ImportExportContext.tsx:127) and then schedules
+      // window.location.reload() at +200ms. The counter increment and
+      // the data-accounts write are BOTH committed to localStorage
+      // before the reload fires, and localStorage survives the reload.
+      //
+      // Do not poll page.evaluate across the reload — the execution
+      // context is destroyed mid-navigation on slower CI runners,
+      // which manifests as "Execution context was destroyed, most
+      // likely because of a navigation". Instead, wait for the reload
+      // to fully settle (load + h1 visible), THEN read localStorage
+      // once. Both assertions are deterministic post-reload.
+      await page.waitForLoadState('load')
       await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible()
 
       const accounts = await page.evaluate(() => localStorage.getItem('data-accounts'))

--- a/e2e/cross-page-home.spec.ts
+++ b/e2e/cross-page-home.spec.ts
@@ -20,15 +20,21 @@ import {
  * in GoalsPeek.tsx, `.mini-progress-pct` in GoalMiniCard.tsx).
  *
  * Adaptations from the spec (documented per-test):
- *  - Test 2 / 33: "Add budget data →" is a plain <span>, not a link.
+ *  - Test 2 / 33 (A): "Add budget data →" is a plain <span>, not a link.
  *    The Enhanced Assertion expecting a click→/budget navigation cannot
  *    pass — see follow-up issue.
- *  - Test 47: Home cards lack per-card ErrorBoundary; we verify the
+ *  - Test 47 (B): Home cards lack per-card ErrorBoundary; we verify the
  *    OBSERVABLE cross-page-isolation contract instead.
- *  - Test 41: AllocationBreakdown on Home reads accounts+balances from
- *    DataContext, not from `allocation-custom-ratios`. The card will
- *    not visually change on `allocation-changed`; we assert the event
- *    fires and Home re-renders cleanly.
+ *  - Test 17 (D): the default seed's 401k balance is below the FI goal;
+ *    we override `balances` to force an over-goal state.
+ *  - Test 39 (E): ImportExportContext schedules a reload ~200ms after
+ *    dispatching `data-changed`. We persist the counter in localStorage
+ *    so it survives the reload, and reset to 0 immediately before the
+ *    trigger so the baseline is unambiguous.
+ *  - Test 41 (F): AllocationBreakdown on Home reads accounts+balances
+ *    from DataContext, not from `allocation-custom-ratios`. The card
+ *    will not visually change on `allocation-changed`; we assert the
+ *    event fires and Home re-renders cleanly.
  */
 
 const HOME = '/finance-tracking/'
@@ -39,6 +45,26 @@ async function gotoHome(page: Page): Promise<void> {
 }
 
 test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.clearCookies()
+    // Clear the one-shot sentinel so each test re-seeds fresh — but
+    // ONLY on the first navigation of the test. The sentinel must
+    // stay set across subsequent in-test navigations or tests that
+    // mutate localStorage mid-session (10, 16, 39, 44, 45) lose
+    // their changes when seedCrossPage's init script re-runs.
+    // sessionStorage is per-context (fresh per test in Playwright's
+    // default isolation), so the gate flag resets between tests.
+    await page.addInitScript(() => {
+      try {
+        if (sessionStorage.getItem('__cross_page_test_started') !== '1') {
+          sessionStorage.setItem('__cross_page_test_started', '1')
+          localStorage.removeItem('__cross_page_seeded')
+        }
+      } catch {
+        /* ignore */
+      }
+    })
+  })
   /* ────────────────────────────────────────────────────────────
    * Flow 1: Budget Savings Rate → Goals Page
    * ──────────────────────────────────────────────────────────── */
@@ -57,8 +83,10 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       await expect(goalsCard).toBeVisible()
       const homeDate = goalsCard.locator('.goals-peek-projected-date')
       await expect(homeDate).toBeVisible()
-      const homeDateText = (await homeDate.textContent())?.trim() || ''
-      expect(homeDateText).toMatch(/^[A-Z][a-z]{2} \d{4}$/)
+      // Strict text-match BEFORE extraction kills the hydration race
+      // where textContent() returns '' before React commits.
+      await expect(homeDate).toHaveText(/^[A-Z][a-z]{2} \d{4}$/)
+      const homeDateText = (await homeDate.textContent())?.trim() ?? ''
 
       // Enhanced assertion: cross-page projection consistency.
       // GoalDetailedCard.tsx:721 renders the same projection via
@@ -68,7 +96,8 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       await page.waitForLoadState('domcontentloaded')
       const detailDate = page.locator('.fi-card-row-value--projected').first()
       await expect(detailDate).toBeVisible()
-      const detailDateText = (await detailDate.textContent())?.trim() || ''
+      await expect(detailDate).toHaveText(/^[A-Z][a-z]{2} \d{4}$/)
+      const detailDateText = (await detailDate.textContent())?.trim() ?? ''
       expect(detailDateText).toBe(homeDateText)
     })
 
@@ -118,7 +147,7 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       // vs. target retirement row uses --ahead or --behind class.
       const diff = page.locator('.fi-card-row-value--ahead, .fi-card-row-value--behind').first()
       await expect(diff).toBeVisible()
-      await expect(diff).toHaveText(/year(s)? (early|behind)|On track/)
+      await expect(diff).toHaveText(/(\d+\s+years?\s+(early|behind)|On\s+track)/)
     })
 
     test('5. Goal detailed card shows "no budget" state when budget-summary is absent', async ({ page }) => {
@@ -200,7 +229,7 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       // Click to expand and ensure the leaf children render.
       await fiNode.click()
       const fiChildren = page.locator('.home-card--nw .nw-tree-children').first()
-      await expect(fiChildren).toBeVisible()
+      await expect(fiChildren).toBeVisible({ timeout: 2000 })
       await expect(fiChildren.locator('.nw-tree-label', { hasText: 'Retirement' })).toBeVisible()
     })
 
@@ -436,6 +465,11 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       await page.getByRole('button', { name: 'Advanced', exact: true }).click()
       await expect(page.getByRole('heading', { level: 3, name: 'Advanced' })).toBeVisible()
 
+      // Reset counter to 0 immediately before the trigger action so the
+      // baseline is unambiguous (C4: listener was installed on first nav,
+      // counter could have been bumped by any prior remount dispatch).
+      await page.evaluate(() => localStorage.setItem('__test_data_changed_count', '0'))
+
       const v2 = buildV2Export()
       await page.locator('input[type="file"][accept=".json"]').setInputFiles({
         name: v2.name,
@@ -443,21 +477,40 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
         buffer: Buffer.from(v2.content),
       })
 
+      // Await the counter increment (C4 poll pattern). ImportExportContext
+      // dispatches `data-changed` synchronously inside the reader.onload
+      // (ImportExportContext.tsx:127) before scheduling reload at +200ms.
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() => Number(localStorage.getItem('__test_data_changed_count') || '0')),
+          { timeout: 5000 },
+        )
+        .toBeGreaterThanOrEqual(1)
+
       // Wait for the post-import reload to settle by polling
       // localStorage for the imported accounts.
       await expect
         .poll(() => page.evaluate(() => localStorage.getItem('data-accounts')), { timeout: 10_000 })
         .toContain('401k')
+      // C5: explicitly wait for the reload to finish before any further
+      // localStorage assertions (Heading-visible proves DataContext mounted).
       await page.waitForLoadState('domcontentloaded')
+      await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible()
 
-      // Counter persisted across reload — `data-changed` fired at least
-      // once during the import. (The post-reload page also re-installs
-      // the listener via addInitScript, so subsequent DataContext mount
-      // events may bump the count further; we only require >= 1.)
+      const accounts = await page.evaluate(() => localStorage.getItem('data-accounts'))
+      expect(accounts).toContain('401k')
+
+      // M6: source dispatches `data-changed` exactly once
+      // (ImportExportContext.tsx:127 — the only production dispatcher).
+      // Reload does NOT re-dispatch on mount (verified: no remount-
+      // dispatch in DataContext). Cap at 5 to catch runaway dispatches
+      // if a future refactor adds remount-on-mount behavior.
       const count = await page.evaluate(() =>
         Number(localStorage.getItem('__test_data_changed_count') || '0'),
       )
       expect(count).toBeGreaterThanOrEqual(1)
+      expect(count).toBeLessThanOrEqual(5)
 
       // Imported balances render in the Home Net Worth card.
       await page.goto(HOME)
@@ -486,8 +539,13 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       await gotoHome(page)
       await expect(page.locator('.home-card--alloc')).toBeVisible()
 
+      // Reset counter to 0 immediately before the trigger action so the
+      // baseline is unambiguous (C4).
+      await page.evaluate(() => localStorage.setItem('__test_alloc_changed_count', '0'))
+
       // Mutate ratios and dispatch the event directly to mirror the
-      // production path (saveCustomRatios appStorage.setJSON + event).
+      // production path (saveCustomRatios appStorage.setJSON + event
+      // dispatched once: allocation/utils.ts:13).
       // Using page.evaluate is the reliable fallback called out in the
       // adaptation note — locating the allocation UI's specific
       // "save ratio" affordance is brittle and out of scope here.
@@ -507,10 +565,23 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
         window.dispatchEvent(new Event('allocation-changed'))
       })
 
+      // Await the counter increment (C4 poll pattern).
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() => Number(localStorage.getItem('__test_alloc_changed_count') || '0')),
+          { timeout: 5000 },
+        )
+        .toBeGreaterThanOrEqual(1)
+
+      // M6: we dispatch the event exactly once above, and saveCustomRatios
+      // (allocation/utils.ts:13) is the only production dispatcher and also
+      // fires once per save. No remount-dispatch occurs. We assert the
+      // strict exact-count contract.
       const count = await page.evaluate(() =>
         Number(localStorage.getItem('__test_alloc_changed_count') || '0'),
       )
-      expect(count).toBeGreaterThanOrEqual(1)
+      expect(count).toBe(1)
 
       // Home re-renders cleanly after navigating away and back.
       await page.goto(URLS.allocation)
@@ -608,6 +679,12 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       // Branch A: route-level boundary tripped.
       // Branch B: corruption silently absorbed and Home rendered.
       const alertCount = await alert.count()
+      // M8: annotate which branch executed so failure investigation
+      // knows which path ran.
+      test.info().annotations.push({
+        type: 'execution-branch',
+        description: alertCount > 0 ? 'A: route-level boundary caught' : 'B: silent absorb',
+      })
       if (alertCount > 0) {
         await expect(alert.first()).toBeVisible()
       } else {
@@ -615,9 +692,15 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
         await expect(homeHeading).toBeVisible()
         const otherCards = page.locator('.home-card--nw, .home-card--alloc, .home-card--charts')
         expect(await otherCards.count()).toBeGreaterThan(0)
+        // M8: strengthen — assert at least the NetWorth card actually
+        // rendered (per-card isolation works in practice on branch B).
+        const nwCard = page.locator('.home-card--nw')
+        await expect(nwCard).toBeVisible()
         // GoalsPeek either renders an empty state or a goals list; we
         // accept either because per-card isolation is not enforced.
-        await expect(goalsCard).toHaveCount(await goalsCard.count())
+        // C2: replace tautological toHaveCount(count) with a real bound.
+        const goalCardCount = await goalsCard.count()
+        expect([0, 1]).toContain(goalCardCount)
       }
 
       // Cross-page isolation: Net Worth always renders normally.

--- a/e2e/cross-page-home.spec.ts
+++ b/e2e/cross-page-home.spec.ts
@@ -1,0 +1,629 @@
+import { test, expect, Page } from '@playwright/test'
+import {
+  buildV2Export,
+  CROSS_PAGE_GOAL,
+  mutateAccountBalance,
+  seedCrossPage,
+  URLS,
+} from './fixtures/cross-page-data'
+
+/**
+ * Sub-issue #151 (62a of 4 under #62) — Home dashboard cross-page
+ * integration. 22 tests across Flow 1 (Budget → Goals), Flow 2
+ * (Balances → Home widgets), Flow 4 (Balances → Goal progress),
+ * edge cases (missing/zero/corrupted data) and event-propagation
+ * additionals (data-changed, allocation-changed).
+ *
+ * Source-truth references are inline next to each assertion so a
+ * future refactor that breaks the contract is easy to trace back
+ * (e.g. `.nw-amount` in NetWorthSummary.tsx, `.goals-peek-projected-date`
+ * in GoalsPeek.tsx, `.mini-progress-pct` in GoalMiniCard.tsx).
+ *
+ * Adaptations from the spec (documented per-test):
+ *  - Test 2 / 33: "Add budget data →" is a plain <span>, not a link.
+ *    The Enhanced Assertion expecting a click→/budget navigation cannot
+ *    pass — see follow-up issue.
+ *  - Test 47: Home cards lack per-card ErrorBoundary; we verify the
+ *    OBSERVABLE cross-page-isolation contract instead.
+ *  - Test 41: AllocationBreakdown on Home reads accounts+balances from
+ *    DataContext, not from `allocation-custom-ratios`. The card will
+ *    not visually change on `allocation-changed`; we assert the event
+ *    fires and Home re-renders cleanly.
+ */
+
+const HOME = '/finance-tracking/'
+
+async function gotoHome(page: Page): Promise<void> {
+  await page.goto(HOME)
+  await page.waitForLoadState('domcontentloaded')
+}
+
+test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
+  /* ────────────────────────────────────────────────────────────
+   * Flow 1: Budget Savings Rate → Goals Page
+   * ──────────────────────────────────────────────────────────── */
+  test.describe('Flow 1: Budget Savings Rate → Goals', () => {
+    test('1. GoalsPeek shows projected FI date derived from budget savings rate', async ({ page }) => {
+      // GoalsPeek.tsx:155 calls projectFIDate(fiTotal=260000, fiGoal=2_000_000,
+      // annualSavings=40_000, growthRate=DEFAULT_PRE_FI_GROWTH_RATE=8). The
+      // `growth: 6` on the goal is intentionally not used here — projectFIDate
+      // hardcodes 8% (goalCalculations.ts:2). We assert the date renders
+      // (format is "MMM YYYY" via toLocaleDateString) and that the same
+      // string appears on the Goal detail page (cross-page consistency).
+      await seedCrossPage(page)
+      await gotoHome(page)
+
+      const goalsCard = page.locator('.home-card--goals')
+      await expect(goalsCard).toBeVisible()
+      const homeDate = goalsCard.locator('.goals-peek-projected-date')
+      await expect(homeDate).toBeVisible()
+      const homeDateText = (await homeDate.textContent())?.trim() || ''
+      expect(homeDateText).toMatch(/^[A-Z][a-z]{2} \d{4}$/)
+
+      // Enhanced assertion: cross-page projection consistency.
+      // GoalDetailedCard.tsx:721 renders the same projection via
+      // `.fi-card-row-value--projected` and identical formatting
+      // (toLocaleDateString('en-US', { month: 'short', year: 'numeric' })).
+      await page.goto(URLS.goalDetail(CROSS_PAGE_GOAL.id))
+      await page.waitForLoadState('domcontentloaded')
+      const detailDate = page.locator('.fi-card-row-value--projected').first()
+      await expect(detailDate).toBeVisible()
+      const detailDateText = (await detailDate.textContent())?.trim() || ''
+      expect(detailDateText).toBe(homeDateText)
+    })
+
+    test('2. GoalsPeek shows "Add budget data →" when budget-summary is missing', async ({ page }) => {
+      // ADAPTATION: "Add budget data →" is rendered as a plain <span>
+      // with class goals-peek-projected--link (GoalsPeek.tsx:148–150,
+      // 179, 197). It has NO click handler and is NOT an <a> or <button>.
+      // The Enhanced Assertion expecting click→/budget navigation cannot
+      // pass as-written. Filed follow-up issue to make this fallback an
+      // actionable <a href="#/budget"> matching GoalDetailedCard.tsx:678.
+      await seedCrossPage(page, { budgetSummary: null })
+      await gotoHome(page)
+
+      const goalsCard = page.locator('.home-card--goals')
+      await expect(goalsCard).toBeVisible()
+      const fallback = goalsCard.locator('.goals-peek-projected--link')
+      await expect(fallback).toBeVisible()
+      await expect(fallback).toHaveText('Add budget data →')
+    })
+
+    test('3. GoalsPeek shows "Not reachable at current rate" when annual savings ≤ 0', async ({ page }) => {
+      // GoalsPeek.tsx:151–153 sets fiProjectedType='not-reachable' when
+      // budgetSaveRate.annualSavings <= 0 → class .goals-peek-projected--warn.
+      await seedCrossPage(page, {
+        budgetSummary: { annualSavings: 0, saveRate: 0, monthsOfData: 3 },
+      })
+      await gotoHome(page)
+
+      const warn = page.locator('.home-card--goals .goals-peek-projected--warn')
+      await expect(warn).toBeVisible()
+      await expect(warn).toHaveText('Not reachable at current rate')
+    })
+
+    test('4. Goal detailed card shows savings projection banner with budget data', async ({ page }) => {
+      // GoalDetailedCard.tsx:696+ renders the projected state when
+      // hasBudgetData && budgetAnnualSavings > 0. Monthly savings is
+      // budgetAnnualSavings / 12 = 40000/12 → $3,333 (via `dollars()`
+      // which rounds: GoalDetailedCard.tsx:65). The vs-target row
+      // renders projection.diffText ("X years early"/"behind").
+      await seedCrossPage(page)
+      await page.goto(URLS.goalDetail(CROSS_PAGE_GOAL.id))
+      await page.waitForLoadState('domcontentloaded')
+
+      await expect(page.locator('.fi-card-row-value--projected').first()).toBeVisible()
+      // Monthly savings row: $3,333 (40000/12 rounded).
+      await expect(page.getByText('$3,333', { exact: true }).first()).toBeVisible()
+      // vs. target retirement row uses --ahead or --behind class.
+      const diff = page.locator('.fi-card-row-value--ahead, .fi-card-row-value--behind').first()
+      await expect(diff).toBeVisible()
+      await expect(diff).toHaveText(/year(s)? (early|behind)|On track/)
+    })
+
+    test('5. Goal detailed card shows "no budget" state when budget-summary is absent', async ({ page }) => {
+      // GoalDetailedCard.tsx:678–685 renders <a href="#/budget"> with
+      // "Add budget data to see projections" when state === 'no-budget'.
+      // The projected-completion row is NOT rendered.
+      await seedCrossPage(page, { budgetSummary: null })
+      await page.goto(URLS.goalDetail(CROSS_PAGE_GOAL.id))
+      await page.waitForLoadState('domcontentloaded')
+
+      const noBudgetLink = page.locator('a.fi-card-projection-link')
+      await expect(noBudgetLink).toBeVisible()
+      await expect(noBudgetLink).toHaveText('Add budget data to see projections')
+      await expect(noBudgetLink).toHaveAttribute('href', '#/budget')
+      // The projected-completion row must NOT appear in the no-budget state.
+      await expect(page.locator('.fi-card-row-value--projected')).toHaveCount(0)
+    })
+  })
+
+  /* ────────────────────────────────────────────────────────────
+   * Flow 2: Account Balances → Home Dashboard Widgets
+   * ──────────────────────────────────────────────────────────── */
+  test.describe('Flow 2: Account Balances → Home Widgets', () => {
+    test('6. Net Worth Summary displays correct total from all account balances', async ({ page }) => {
+      // NetWorthSummary.tsx:207 → `.nw-amount` = formatCurrency(netWorth)
+      // where netWorth = sum over all accounts of latest-month balance.
+      // 401k=$260,000 + Savings=$55,000 = $315,000 (Apr 2025 is latest).
+      // formatCurrency uses Intl en-US → "$315,000" (no cents).
+      await seedCrossPage(page)
+      await gotoHome(page)
+
+      const nwCard = page.locator('.home-card--nw')
+      await expect(nwCard).toBeVisible()
+      const nwAmount = nwCard.locator('.nw-amount')
+      await expect(nwAmount).toContainText('$315,000')
+      await expect(nwCard.locator('.nw-date')).toHaveText('Apr 2025')
+
+      // Enhanced cross-page assertion (#151 spec): the Net Worth page
+      // must read the same data from localStorage. The Net Worth page
+      // does not surface a single "total" element (it's tabbed), so we
+      // verify cross-page consistency by:
+      //   1. recomputing the expected total from localStorage on /net-worth,
+      //   2. confirming it equals the Home `.nw-amount` value.
+      await page.goto(URLS.netWorth)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.getByRole('heading', { level: 1, name: 'Net Worth' })).toBeVisible()
+
+      const total = await page.evaluate(() => {
+        const bs = JSON.parse(localStorage.getItem('data-balances') || '[]') as {
+          accountId: number
+          month: string
+          balance: number
+        }[]
+        const months = [...new Set(bs.map(b => b.month))].sort()
+        const latest = months[months.length - 1]
+        return bs.filter(b => b.month === latest).reduce((s, b) => s + b.balance, 0)
+      })
+      expect(total).toBe(315_000)
+    })
+
+    test('7. Net Worth Summary shows FI and GW subtotals in expandable tree', async ({ page }) => {
+      // NetWorthSummary.tsx:264–282: each tree node is a <button> with
+      // class .nw-tree-node--parent and a child .nw-tree-label holding
+      // "FI" or "GW". The .nw-tree-value sibling holds the formatted
+      // total: FI=$260,000 (401k only), GW=$55,000 (Savings only).
+      await seedCrossPage(page)
+      await gotoHome(page)
+
+      const fiNode = page
+        .locator('.home-card--nw .nw-tree-node--parent')
+        .filter({ has: page.locator('.nw-tree-label', { hasText: /^FI$/ }) })
+      const gwNode = page
+        .locator('.home-card--nw .nw-tree-node--parent')
+        .filter({ has: page.locator('.nw-tree-label', { hasText: /^GW$/ }) })
+
+      await expect(fiNode.locator('.nw-tree-value')).toHaveText('$260,000')
+      await expect(gwNode.locator('.nw-tree-value')).toHaveText('$55,000')
+
+      // Click to expand and ensure the leaf children render.
+      await fiNode.click()
+      const fiChildren = page.locator('.home-card--nw .nw-tree-children').first()
+      await expect(fiChildren).toBeVisible()
+      await expect(fiChildren.locator('.nw-tree-label', { hasText: 'Retirement' })).toBeVisible()
+    })
+
+    test('8. Mini Charts card renders net worth line chart with SVG data points', async ({ page }) => {
+      // MiniCharts.tsx:208 → <h3>Charts</h3>; default tab is "net-worth"
+      // (MiniCharts.tsx:31). Recharts renders <svg> with <path> for the
+      // line series.
+      await seedCrossPage(page)
+      await gotoHome(page)
+
+      const chartsCard = page.locator('.home-card--charts')
+      await expect(chartsCard).toBeVisible()
+      await expect(chartsCard.getByRole('heading', { level: 3, name: 'Charts' })).toBeVisible()
+      await expect(chartsCard.getByRole('button', { name: 'Net Worth', exact: true })).toBeVisible()
+      // Default active tab is "Net Worth" — recharts renders svg + path.
+      await expect(chartsCard.locator('svg path').first()).toBeVisible()
+    })
+
+    test('9. Allocation card splits accounts by goalType and allocation', async ({ page }) => {
+      // AllocationBreakdown.tsx renders three <h4 class="alloc-section-title">
+      // sections: Total, FI, GW. Each section's .alloc-legend-row lists
+      // the allocation labels (ALLOCATION_LABELS in types.ts: cash="Cash",
+      // us-stock="US Stock"). With only 401k($260k, us-stock) under FI
+      // and Savings($55k, cash) under GW, each section shows 100%.
+      await seedCrossPage(page)
+      await gotoHome(page)
+
+      const allocCard = page.locator('.home-card--alloc')
+      await expect(allocCard).toBeVisible()
+
+      const fiSection = allocCard
+        .locator('.alloc-section')
+        .filter({ has: page.locator('.alloc-section-title', { hasText: /^FI$/ }) })
+      await expect(fiSection.locator('.alloc-legend-label', { hasText: 'US Stock' })).toBeVisible()
+      await expect(fiSection.locator('.alloc-legend-pct')).toHaveText('100%')
+
+      const gwSection = allocCard
+        .locator('.alloc-section')
+        .filter({ has: page.locator('.alloc-section-title', { hasText: /^GW$/ }) })
+      await expect(gwSection.locator('.alloc-legend-label', { hasText: 'Cash' })).toBeVisible()
+      await expect(gwSection.locator('.alloc-legend-pct')).toHaveText('100%')
+    })
+
+    test('10. Home dashboard reflects updated balances after navigating away and back', async ({ page }) => {
+      // ADAPTATION: programmatic localStorage writes within the same window
+      // do NOT fire the native `storage` event (it only fires cross-tab).
+      // To observably refresh the cards we mutate the row then dispatch
+      // `data-changed` manually — DataContext.tsx:57 listens for that and
+      // re-reads from localStorage. We also navigate away and back to
+      // confirm the round-trip is stable (the DataContext should hold
+      // the updated state across hash-route changes).
+      await seedCrossPage(page)
+      await gotoHome(page)
+      await expect(page.locator('.home-card--nw .nw-amount')).toContainText('$315,000')
+
+      await page.goto(URLS.netWorth)
+      await page.waitForLoadState('domcontentloaded')
+      await mutateAccountBalance(page, 1, '2025-04', 300_000)
+      // Wait a tick for React state to settle from the dispatched event.
+      await expect(page.getByRole('heading', { level: 1, name: 'Net Worth' })).toBeVisible()
+
+      await page.goto(HOME)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.locator('.home-card--nw .nw-amount')).toContainText('$355,000')
+    })
+  })
+
+  /* ────────────────────────────────────────────────────────────
+   * Flow 4: Account Balances → Goal Progress Percentages
+   * ──────────────────────────────────────────────────────────── */
+  test.describe('Flow 4: Account Balances → Goal Progress', () => {
+    test('14. GoalMiniCard shows correct FI progress from account balances', async ({ page }) => {
+      // GoalMiniCard.tsx:62 clamps to [0, 100] of (fiTotal/fiGoal)*100.
+      // 260000 / 2000000 = 0.13 → 13% via .toFixed(0) (GoalMiniCard.tsx:94).
+      await seedCrossPage(page)
+      await page.goto(URLS.goal)
+      await page.waitForLoadState('domcontentloaded')
+
+      const pct = page.locator('.mini-progress-pct').first()
+      await expect(pct).toBeVisible()
+      await expect(pct).toHaveText('13%')
+    })
+
+    test('15. GoalsPeek FI progress bar matches account balance / fiGoal ratio', async ({ page }) => {
+      // GoalsPeek.tsx:209–212 — progressbar has role="progressbar" and
+      // aria-valuenow=Math.round(fiPct). 260000/2000000*100 = 13 → 13.
+      // The .goals-peek-pct--fi sibling shows the same value with %.
+      await seedCrossPage(page)
+      await gotoHome(page)
+
+      const progressbar = page.locator('.home-card--goals [role="progressbar"]').first()
+      await expect(progressbar).toHaveAttribute('aria-valuenow', '13')
+      await expect(progressbar).toHaveAttribute('aria-valuemin', '0')
+      await expect(progressbar).toHaveAttribute('aria-valuemax', '100')
+      await expect(page.locator('.home-card--goals .goals-peek-pct--fi').first()).toHaveText('13%')
+    })
+
+    test('16. FI progress updates when account balance changes', async ({ page }) => {
+      // GoalMiniCard reads via getLatestGoalTotals() inside a useMemo whose
+      // dep array is [goal.fiGoal] only (GoalMiniCard.tsx:59–63). A bare
+      // balance mutation will NOT re-trigger the memo on the same mount,
+      // so the spec calls for a page reload, which is what we do here.
+      await seedCrossPage(page)
+      await page.goto(URLS.goal)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.locator('.mini-progress-pct').first()).toHaveText('13%')
+
+      await mutateAccountBalance(page, 1, '2025-04', 500_000)
+      await page.reload()
+      await page.waitForLoadState('domcontentloaded')
+      // 500000 / 2000000 = 0.25 → 25%
+      await expect(page.locator('.mini-progress-pct').first()).toHaveText('25%')
+    })
+
+    test('17. FI progress caps at 100% when balance exceeds goal', async ({ page }) => {
+      // ADAPTATION (E): the default seed's 401k balance is $260k. To
+      // exceed the $2M fiGoal we override `balances` to put account 1
+      // at $3M for the latest month, leaving the other rows alone.
+      // GoalMiniCard.tsx:62 clamps via Math.min(100, ...).
+      await seedCrossPage(page, {
+        balances: [
+          { id: 1, accountId: 1, month: '2025-03', balance: 250_000 },
+          { id: 2, accountId: 1, month: '2025-04', balance: 3_000_000 },
+          { id: 3, accountId: 2, month: '2025-03', balance: 50_000 },
+          { id: 4, accountId: 2, month: '2025-04', balance: 55_000 },
+        ],
+      })
+      await page.goto(URLS.goal)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.locator('.mini-progress-pct').first()).toHaveText('100%')
+    })
+  })
+
+  /* ────────────────────────────────────────────────────────────
+   * Edge Cases
+   * ──────────────────────────────────────────────────────────── */
+  test.describe('Edge Cases', () => {
+    test('33. Home dashboard handles missing budget-summary gracefully', async ({ page }) => {
+      // ADAPTATION (A): the spec's Enhanced Assertion expects the
+      // "Add budget data →" string to be a functioning link that
+      // navigates to /budget when clicked. The element is a plain
+      // <span> with no click handler (GoalsPeek.tsx:197) — see test 2
+      // adaptation. We assert the fallback renders, no console errors
+      // surface, and the rest of the Home dashboard cards still render.
+      const pageErrors: string[] = []
+      page.on('pageerror', e => pageErrors.push(e.message))
+
+      await seedCrossPage(page, { budgetSummary: null })
+      await gotoHome(page)
+
+      const fallback = page.locator('.home-card--goals .goals-peek-projected--link')
+      await expect(fallback).toBeVisible()
+      await expect(fallback).toHaveText('Add budget data →')
+      // Other cards continue to render normally.
+      await expect(page.locator('.home-card--nw .nw-amount')).toContainText('$315,000')
+      await expect(page.locator('.home-card--alloc')).toBeVisible()
+      await expect(page.locator('.home-card--charts')).toBeVisible()
+      expect(pageErrors).toEqual([])
+    })
+
+    test('34. Goal progress shows 0% when no balances exist for FI accounts', async ({ page }) => {
+      // GoalMiniCard.tsx:60–63: fiTotal=0 when no balances → 0%. The
+      // goal must still render (so .mini-progress-pct exists).
+      await seedCrossPage(page, { accounts: null, balances: null })
+      await page.goto(URLS.goal)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.locator('.mini-progress-pct').first()).toHaveText('0%')
+    })
+
+    test('36. Net Worth card handles accounts with zero balances', async ({ page }) => {
+      // Force every latest-month balance to 0. formatCurrency(0) → "$0".
+      await seedCrossPage(page, {
+        balances: [
+          { id: 1, accountId: 1, month: '2025-04', balance: 0 },
+          { id: 2, accountId: 2, month: '2025-04', balance: 0 },
+        ],
+      })
+      await gotoHome(page)
+
+      const nwCard = page.locator('.home-card--nw')
+      await expect(nwCard.locator('.nw-amount')).toContainText('$0')
+
+      const fiValue = nwCard
+        .locator('.nw-tree-node--parent')
+        .filter({ has: page.locator('.nw-tree-label', { hasText: /^FI$/ }) })
+        .locator('.nw-tree-value')
+      const gwValue = nwCard
+        .locator('.nw-tree-node--parent')
+        .filter({ has: page.locator('.nw-tree-label', { hasText: /^GW$/ }) })
+        .locator('.nw-tree-value')
+      await expect(fiValue).toHaveText('$0')
+      await expect(gwValue).toHaveText('$0')
+    })
+  })
+
+  /* ────────────────────────────────────────────────────────────
+   * Additional Tests — event propagation, mid-session mutation,
+   * corrupted-key isolation.
+   * ──────────────────────────────────────────────────────────── */
+  test.describe('Additional Tests', () => {
+    test('39. Import triggers data-changed and Home renders imported data', async ({ page }) => {
+      // ADAPTATION (E): ImportExportContext.tsx:127–128 dispatches
+      // `data-changed` THEN schedules window.location.reload() ~200ms
+      // later. To count the event across the reload we persist a
+      // counter in localStorage (NOT on window) so it survives the
+      // reload. addInitScript re-installs the listener on every
+      // navigation/reload after addInitScript is called.
+      //
+      // Seed shape: start from an empty app, then import a payload
+      // that re-populates accounts + balances + goals + budget. After
+      // the reload settles we navigate to Home and assert the imported
+      // values render in the dashboard cards.
+      await seedCrossPage(page, {
+        accounts: null,
+        balances: null,
+        goals: null,
+        budgetSummary: null,
+        budgetStore: null,
+      })
+      await page.addInitScript(() => {
+        window.addEventListener('data-changed', () => {
+          const n = Number(localStorage.getItem('__test_data_changed_count') || '0') + 1
+          localStorage.setItem('__test_data_changed_count', String(n))
+        })
+      })
+      await gotoHome(page)
+
+      // Open Settings → Advanced → Import. The dialog's import file
+      // input is hidden by `display:none` (AdvancedPane.tsx:76), so we
+      // set files directly on the input.
+      await page.getByRole('button', { name: 'Settings', exact: true }).click()
+      await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible()
+      await page.getByRole('button', { name: 'Advanced', exact: true }).click()
+      await expect(page.getByRole('heading', { level: 3, name: 'Advanced' })).toBeVisible()
+
+      const v2 = buildV2Export()
+      await page.locator('input[type="file"][accept=".json"]').setInputFiles({
+        name: v2.name,
+        mimeType: 'application/json',
+        buffer: Buffer.from(v2.content),
+      })
+
+      // Wait for the post-import reload to settle by polling
+      // localStorage for the imported accounts.
+      await expect
+        .poll(() => page.evaluate(() => localStorage.getItem('data-accounts')), { timeout: 10_000 })
+        .toContain('401k')
+      await page.waitForLoadState('domcontentloaded')
+
+      // Counter persisted across reload — `data-changed` fired at least
+      // once during the import. (The post-reload page also re-installs
+      // the listener via addInitScript, so subsequent DataContext mount
+      // events may bump the count further; we only require >= 1.)
+      const count = await page.evaluate(() =>
+        Number(localStorage.getItem('__test_data_changed_count') || '0'),
+      )
+      expect(count).toBeGreaterThanOrEqual(1)
+
+      // Imported balances render in the Home Net Worth card.
+      await page.goto(HOME)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.locator('.home-card--nw .nw-amount')).toContainText('$315,000')
+    })
+
+    test('41. Allocation ratio update fires allocation-changed and Home stays consistent', async ({
+      page,
+    }) => {
+      // ADAPTATION (F): the Home AllocationBreakdown card consumes
+      // accounts + balances from DataContext — it does NOT read
+      // `allocation-custom-ratios`. So a ratios mutation will NOT
+      // visually change the Home card. We assert the OBSERVABLE
+      // contract: the `allocation-changed` event fires (it is
+      // dispatched by saveCustomRatios in pages/allocation/utils.ts:13)
+      // and Home continues to render the allocation card cleanly on
+      // re-navigation.
+      await seedCrossPage(page)
+      await page.addInitScript(() => {
+        window.addEventListener('allocation-changed', () => {
+          const n = Number(localStorage.getItem('__test_alloc_changed_count') || '0') + 1
+          localStorage.setItem('__test_alloc_changed_count', String(n))
+        })
+      })
+      await gotoHome(page)
+      await expect(page.locator('.home-card--alloc')).toBeVisible()
+
+      // Mutate ratios and dispatch the event directly to mirror the
+      // production path (saveCustomRatios appStorage.setJSON + event).
+      // Using page.evaluate is the reliable fallback called out in the
+      // adaptation note — locating the allocation UI's specific
+      // "save ratio" affordance is brittle and out of scope here.
+      await page.evaluate(() => {
+        const next = [
+          {
+            id: 'r-test',
+            name: 'Test Ratio',
+            scope: 'total',
+            groups: [
+              { label: 'A', classes: [] },
+              { label: 'B', classes: [] },
+            ],
+          },
+        ]
+        localStorage.setItem('allocation-custom-ratios', JSON.stringify(next))
+        window.dispatchEvent(new Event('allocation-changed'))
+      })
+
+      const count = await page.evaluate(() =>
+        Number(localStorage.getItem('__test_alloc_changed_count') || '0'),
+      )
+      expect(count).toBeGreaterThanOrEqual(1)
+
+      // Home re-renders cleanly after navigating away and back.
+      await page.goto(URLS.allocation)
+      await page.waitForLoadState('domcontentloaded')
+      await page.goto(HOME)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.locator('.home-card--alloc')).toBeVisible()
+      await expect(page.locator('.home-card--nw .nw-amount')).toContainText('$315,000')
+    })
+
+    test('44. Deleting data-balances mid-session is handled gracefully', async ({ page }) => {
+      // Verifies cross-page isolation when balances disappear: Net Worth
+      // page renders (empty state), Home cards downgrade to zero/empty
+      // without crashing, no unhandled exceptions reach pageerror.
+      const pageErrors: string[] = []
+      page.on('pageerror', e => pageErrors.push(e.message))
+
+      await seedCrossPage(page)
+      await gotoHome(page)
+      await expect(page.locator('.home-card--nw .nw-amount')).toContainText('$315,000')
+
+      await page.evaluate(() => {
+        localStorage.removeItem('data-balances')
+        window.dispatchEvent(new Event('data-changed'))
+      })
+
+      await page.goto(URLS.netWorth)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.getByRole('heading', { level: 1, name: 'Net Worth' })).toBeVisible()
+
+      await page.goto(HOME)
+      await page.waitForLoadState('domcontentloaded')
+      // With no balances, NetWorthSummary takes its empty-state branch
+      // (NetWorthSummary.tsx:149) and renders the "Add your data →" CTA
+      // instead of `.nw-amount`. GoalsPeek (no FI total) and Allocation
+      // (balances.length===0) also show their empty-state CTAs without
+      // crashing.
+      const nwCard = page.locator('.home-card--nw')
+      await expect(nwCard).toBeVisible()
+      await expect(nwCard.locator('.nw-amount')).toHaveCount(0)
+      await expect(nwCard.getByRole('button', { name: 'Add your data →' })).toBeVisible()
+      await expect(page.locator('.home-card--goals')).toBeVisible()
+      await expect(page.locator('.home-card--alloc')).toBeVisible()
+      expect(pageErrors).toEqual([])
+    })
+
+    test('45. Clearing budget-summary shows fallback link in GoalsPeek', async ({ page }) => {
+      // Mid-session removal: started with a projected FI date, then
+      // budget-summary disappears. GoalsPeek calls getBudgetSaveRate()
+      // each render (GoalsPeek.tsx — no memo around the budget read),
+      // so a re-render after navigation picks up the change without
+      // a reload. We navigate away and back to force the re-render.
+      const pageErrors: string[] = []
+      page.on('pageerror', e => pageErrors.push(e.message))
+
+      await seedCrossPage(page)
+      await gotoHome(page)
+      await expect(page.locator('.home-card--goals .goals-peek-projected-date')).toBeVisible()
+
+      await page.evaluate(() => {
+        localStorage.removeItem('budget-summary')
+      })
+      await page.goto(URLS.goal)
+      await page.waitForLoadState('domcontentloaded')
+      await page.goto(HOME)
+      await page.waitForLoadState('domcontentloaded')
+
+      const fallback = page.locator('.home-card--goals .goals-peek-projected--link')
+      await expect(fallback).toBeVisible()
+      await expect(fallback).toHaveText('Add budget data →')
+      expect(pageErrors).toEqual([])
+    })
+
+    test('47. Corrupted financialGoals — error isolation across pages', async ({ page }) => {
+      // ADAPTATION (B): Home cards are NOT individually wrapped in
+      // <ErrorBoundary variant="card">. Only the route-level boundary
+      // (App.tsx:166) catches errors. True per-card isolation requires
+      // a source change; filed as follow-up. This test verifies the
+      // OBSERVABLE contract: corrupted financialGoals either (a) is
+      // silently absorbed by appStorage.getJSON's try/catch and Home
+      // renders normally, or (b) trips the route-level boundary which
+      // renders role="alert". Net Worth page renders correctly either
+      // way (cross-page isolation).
+      await seedCrossPage(page)
+      await page.addInitScript(() => {
+        // Run after seedCrossPage's init script — corrupt the key.
+        localStorage.setItem('financialGoals', 'not-valid-json')
+      })
+      await gotoHome(page)
+
+      const alert = page.getByRole('alert')
+      const goalsCard = page.locator('.home-card--goals')
+      const homeHeading = page.getByRole('heading', { level: 1 }).first()
+
+      // Branch A: route-level boundary tripped.
+      // Branch B: corruption silently absorbed and Home rendered.
+      const alertCount = await alert.count()
+      if (alertCount > 0) {
+        await expect(alert.first()).toBeVisible()
+      } else {
+        // Home rendered — at least one of the four cards is on the page.
+        await expect(homeHeading).toBeVisible()
+        const otherCards = page.locator('.home-card--nw, .home-card--alloc, .home-card--charts')
+        expect(await otherCards.count()).toBeGreaterThan(0)
+        // GoalsPeek either renders an empty state or a goals list; we
+        // accept either because per-card isolation is not enforced.
+        await expect(goalsCard).toHaveCount(await goalsCard.count())
+      }
+
+      // Cross-page isolation: Net Worth always renders normally.
+      await page.goto(URLS.netWorth)
+      await page.waitForLoadState('domcontentloaded')
+      await expect(page.getByRole('heading', { level: 1, name: 'Net Worth' })).toBeVisible()
+    })
+  })
+})

--- a/e2e/fixtures/cross-page-data.ts
+++ b/e2e/fixtures/cross-page-data.ts
@@ -1,0 +1,336 @@
+import { Page } from '@playwright/test'
+
+/**
+ * Shared seed for the cross-page integration suites (#151 + future
+ * 62b/c/d → #152/#153/#154). Centralizes the "all 13 sensitive keys
+ * + feature-flags mock" baseline so each spec can layer overrides on
+ * top without re-declaring 100 lines of localStorage seeding.
+ *
+ * Encryption is intentionally disabled (`encryption-enabled: '0'`),
+ * which makes `appStorage.getJSON` read plaintext JSON directly out
+ * of localStorage — matching demoMode.ts and the existing nav-data /
+ * home.fixtures patterns.
+ */
+
+export interface CrossPageSeed {
+  accounts: unknown[]
+  balances: unknown[]
+  goals: unknown[]
+  gwGoals: unknown[]
+  profile: { name: string; birthday: string; avatarDataUrl: string }
+  budgetSummary: { annualSavings: number; saveRate: number; monthsOfData: number } | null
+  budgetStore: unknown
+  budgetConfig: unknown
+  allocationCustomRatios: unknown[]
+  fiSimulations: unknown[]
+  sgtOverrides: unknown
+  taxStore: unknown
+  taxTemplates: unknown[]
+}
+
+export const CROSS_PAGE_PROFILE = {
+  name: 'Casey',
+  birthday: '1990-06-15',
+  avatarDataUrl: '',
+}
+
+export const CROSS_PAGE_ACCOUNTS = [
+  {
+    id: 1,
+    name: '401k',
+    type: 'retirement',
+    owner: 'primary',
+    status: 'active',
+    goalType: 'fi',
+    nature: 'asset',
+    allocation: 'us-stock',
+  },
+  {
+    id: 2,
+    name: 'Savings',
+    type: 'liquid',
+    owner: 'primary',
+    status: 'active',
+    goalType: 'gw',
+    nature: 'asset',
+    allocation: 'cash',
+  },
+]
+
+export const CROSS_PAGE_BALANCES = [
+  { id: 1, accountId: 1, month: '2025-03', balance: 250000 },
+  { id: 2, accountId: 1, month: '2025-04', balance: 260000 },
+  { id: 3, accountId: 2, month: '2025-03', balance: 50000 },
+  { id: 4, accountId: 2, month: '2025-04', balance: 55000 },
+]
+
+export const CROSS_PAGE_GOAL = {
+  id: 1,
+  goalName: 'Early Retirement',
+  fiGoal: 2_000_000,
+  retirementAge: 55,
+  goalCreatedIn: '2024-01-01',
+  goalEndYear: '2060-01-01',
+  expenseValue: 60_000,
+  monthlyExpenseValue: 5_000,
+  expenseValue2047: 96_000,
+  monthlyExpense2047: 8_000,
+  inflationRate: 3,
+  safeWithdrawalRate: 4,
+  growth: 6,
+  birthday: '',
+}
+
+export const CROSS_PAGE_BUDGET_SUMMARY = {
+  annualSavings: 40_000,
+  saveRate: 35,
+  monthsOfData: 3,
+}
+
+/**
+ * Minimal budget-store shape. GoalsPeek consumes `budget-summary` (read
+ * by `getBudgetSaveRate`) — it does NOT re-parse the CSVs. The store
+ * here exists so import/export round-trips and budget-page renders
+ * don't crash. Three months of CSV-like entries satisfy the spec's
+ * "at least 3 months" prereq without recomputing the summary on mount.
+ */
+export const CROSS_PAGE_BUDGET_STORE = {
+  csvs: {
+    '2024-10': {
+      month: '2024-10',
+      csv: 'Date,Category,Amount\n2024-10-01,Salary,8500\n2024-10-05,Rent,-2000',
+      uploadedAt: '2024-10-15T00:00:00.000Z',
+    },
+    '2024-11': {
+      month: '2024-11',
+      csv: 'Date,Category,Amount\n2024-11-01,Salary,8500\n2024-11-05,Rent,-2000',
+      uploadedAt: '2024-11-15T00:00:00.000Z',
+    },
+    '2024-12': {
+      month: '2024-12',
+      csv: 'Date,Category,Amount\n2024-12-01,Salary,8500\n2024-12-05,Rent,-2000',
+      uploadedAt: '2024-12-15T00:00:00.000Z',
+    },
+  },
+  configs: {},
+  years: [2024],
+  categoryGroups: [
+    { id: 'others', name: 'Others', categories: [] },
+    { id: 'removed', name: 'Remove from Budget', categories: [] },
+  ],
+}
+
+export const CROSS_PAGE_BUDGET_CONFIG = {
+  version: 1,
+  years: [2024],
+  categoryGroups: [
+    { id: 'others', name: 'Others', categories: [] },
+    { id: 'removed', name: 'Remove from Budget', categories: [] },
+  ],
+}
+
+export const CROSS_PAGE_SEED: CrossPageSeed = {
+  accounts: CROSS_PAGE_ACCOUNTS,
+  balances: CROSS_PAGE_BALANCES,
+  goals: [CROSS_PAGE_GOAL],
+  gwGoals: [],
+  profile: CROSS_PAGE_PROFILE,
+  budgetSummary: CROSS_PAGE_BUDGET_SUMMARY,
+  budgetStore: CROSS_PAGE_BUDGET_STORE,
+  budgetConfig: CROSS_PAGE_BUDGET_CONFIG,
+  allocationCustomRatios: [],
+  fiSimulations: [],
+  sgtOverrides: {},
+  taxStore: {},
+  taxTemplates: [],
+}
+
+/**
+ * Per-key overrides. `null` for `budgetSummary` deletes the key (used
+ * by the "missing budget" tests). Any field omitted falls back to the
+ * default in `CROSS_PAGE_SEED`.
+ */
+export type SeedOverrides = Partial<{
+  accounts: unknown[] | null
+  balances: unknown[] | null
+  goals: unknown[] | null
+  gwGoals: unknown[] | null
+  profile: typeof CROSS_PAGE_PROFILE | null
+  budgetSummary: typeof CROSS_PAGE_BUDGET_SUMMARY | null
+  budgetStore: unknown | null
+  budgetConfig: unknown | null
+  allocationCustomRatios: unknown[] | null
+  fiSimulations: unknown[] | null
+  sgtOverrides: unknown | null
+  taxStore: unknown | null
+  taxTemplates: unknown[] | null
+}>
+
+/**
+ * Seed localStorage with the cross-page baseline. Mock the
+ * feature-flags fetch (same pattern as seedNav) to keep test logs
+ * free of GitHub anonymous-rate-limit 403s.
+ *
+ * Pass `null` for any field to OMIT that key from localStorage
+ * (e.g. `{ budgetSummary: null }` → no `budget-summary` key written).
+ */
+export async function seedCrossPage(page: Page, overrides: SeedOverrides = {}): Promise<void> {
+  await page.route(
+    'https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json',
+    async route => {
+      const content = Buffer.from(JSON.stringify({ flags: {} })).toString('base64')
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content, encoding: 'base64' }),
+      })
+    },
+  )
+
+  const resolved = {
+    accounts: 'accounts' in overrides ? overrides.accounts : CROSS_PAGE_SEED.accounts,
+    balances: 'balances' in overrides ? overrides.balances : CROSS_PAGE_SEED.balances,
+    goals: 'goals' in overrides ? overrides.goals : CROSS_PAGE_SEED.goals,
+    gwGoals: 'gwGoals' in overrides ? overrides.gwGoals : CROSS_PAGE_SEED.gwGoals,
+    profile: 'profile' in overrides ? overrides.profile : CROSS_PAGE_SEED.profile,
+    budgetSummary: 'budgetSummary' in overrides ? overrides.budgetSummary : CROSS_PAGE_SEED.budgetSummary,
+    budgetStore: 'budgetStore' in overrides ? overrides.budgetStore : CROSS_PAGE_SEED.budgetStore,
+    budgetConfig: 'budgetConfig' in overrides ? overrides.budgetConfig : CROSS_PAGE_SEED.budgetConfig,
+    allocationCustomRatios:
+      'allocationCustomRatios' in overrides
+        ? overrides.allocationCustomRatios
+        : CROSS_PAGE_SEED.allocationCustomRatios,
+    fiSimulations: 'fiSimulations' in overrides ? overrides.fiSimulations : CROSS_PAGE_SEED.fiSimulations,
+    sgtOverrides: 'sgtOverrides' in overrides ? overrides.sgtOverrides : CROSS_PAGE_SEED.sgtOverrides,
+    taxStore: 'taxStore' in overrides ? overrides.taxStore : CROSS_PAGE_SEED.taxStore,
+    taxTemplates: 'taxTemplates' in overrides ? overrides.taxTemplates : CROSS_PAGE_SEED.taxTemplates,
+  }
+
+  await page.addInitScript(data => {
+    // One-shot sentinel: addInitScript runs on EVERY navigation/reload,
+    // but tests that mutate or delete keys mid-session and then trigger
+    // a route change (or rely on the in-app reload after import) must
+    // not have their changes overwritten. The sentinel lets the first
+    // navigation seed the baseline and every subsequent navigation skip.
+    if (localStorage.getItem('__cross_page_seeded') === '1') return
+    localStorage.clear()
+    localStorage.setItem('__cross_page_seeded', '1')
+    localStorage.setItem('encryption-enabled', '0')
+    localStorage.setItem('onboarding-dismissed', '1')
+    localStorage.setItem('darkMode', '0')
+
+    const writeIf = (key: string, value: unknown) => {
+      if (value === null || value === undefined) return
+      localStorage.setItem(key, JSON.stringify(value))
+    }
+    writeIf('user-profile', data.profile)
+    writeIf('data-accounts', data.accounts)
+    writeIf('data-balances', data.balances)
+    writeIf('financialGoals', data.goals)
+    writeIf('gw-goals', data.gwGoals)
+    writeIf('budget-summary', data.budgetSummary)
+    writeIf('budget-store', data.budgetStore)
+    writeIf('budget-config', data.budgetConfig)
+    writeIf('allocation-custom-ratios', data.allocationCustomRatios)
+    writeIf('fi-simulations', data.fiSimulations)
+    writeIf('sgt-overrides', data.sgtOverrides)
+    writeIf('tax-store', data.taxStore)
+    writeIf('tax-templates', data.taxTemplates)
+  }, resolved)
+}
+
+/**
+ * Mutate a single balance row in-place via `page.evaluate`, then fire
+ * `data-changed` so DataContext (which subscribes via
+ * `window.addEventListener('data-changed', ...)`, see
+ * DataContext.tsx:57) reloads accounts/balances without a page reload.
+ *
+ * If no row matches (accountId, month) a new row is appended with a
+ * fresh id = max(existing) + 1.
+ */
+export async function mutateAccountBalance(
+  page: Page,
+  accountId: number,
+  month: string,
+  newBalance: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ accountId, month, newBalance }) => {
+      const raw = localStorage.getItem('data-balances') || '[]'
+      const list = JSON.parse(raw) as { id: number; accountId: number; month: string; balance: number }[]
+      const idx = list.findIndex(b => b.accountId === accountId && b.month === month)
+      if (idx >= 0) {
+        list[idx] = { ...list[idx], balance: newBalance }
+      } else {
+        const nextId = list.reduce((m, b) => Math.max(m, b.id), 0) + 1
+        list.push({ id: nextId, accountId, month, balance: newBalance })
+      }
+      localStorage.setItem('data-balances', JSON.stringify(list))
+      window.dispatchEvent(new Event('data-changed'))
+    },
+    { accountId, month, newBalance },
+  )
+}
+
+/**
+ * Build a minimal v2 export JSON (matching the 15 top-level keys
+ * written by `handleExport` in src/contexts/ImportExportContext.tsx).
+ * Used by the import-event test to exercise the full
+ * file-pick → FileReader → data-changed → reload pipeline.
+ */
+export function buildV2Export(
+  overrides: Partial<{
+    goals: unknown[]
+    gwGoals: unknown[]
+    profile: typeof CROSS_PAGE_PROFILE
+    dataAccounts: unknown[]
+    dataBalances: unknown[]
+    budgetCsvs: unknown
+    budgetConfig: unknown
+    allocationCustomRatios: unknown[]
+    taxStore: unknown
+    taxTemplates: unknown[]
+    fiSimulations: unknown[]
+    sgtOverrides: unknown
+    settings: Record<string, unknown>
+  }> = {},
+): { name: string; content: string } {
+  const payload = {
+    version: 2,
+    exportedAt: new Date().toISOString(),
+    goals: overrides.goals ?? [CROSS_PAGE_GOAL],
+    gwGoals: overrides.gwGoals ?? [],
+    profile: overrides.profile ?? CROSS_PAGE_PROFILE,
+    settings: overrides.settings ?? {
+      accentTheme: 'teal',
+      darkMode: false,
+      allowCsvImport: true,
+      goalViewMode: '',
+      homeCardOrder: JSON.stringify([0, 1, 2, 3]),
+    },
+    dataAccounts: overrides.dataAccounts ?? CROSS_PAGE_ACCOUNTS,
+    dataBalances: overrides.dataBalances ?? CROSS_PAGE_BALANCES,
+    budgetCsvs: overrides.budgetCsvs ?? CROSS_PAGE_BUDGET_STORE.csvs,
+    budgetConfig: overrides.budgetConfig ?? {
+      years: CROSS_PAGE_BUDGET_STORE.years,
+      categoryGroups: CROSS_PAGE_BUDGET_STORE.categoryGroups,
+    },
+    fiSimulations: overrides.fiSimulations ?? [],
+    sgtOverrides: overrides.sgtOverrides ?? {},
+    allocationCustomRatios: overrides.allocationCustomRatios ?? [],
+    taxStore: overrides.taxStore ?? {},
+    taxTemplates: overrides.taxTemplates ?? [],
+  }
+  return { name: 'v2-cross-page.json', content: JSON.stringify(payload) }
+}
+
+/** Convenience URLs under the Vite dev base + HashRouter. */
+export const URLS = {
+  base: '/finance-tracking/',
+  home: '/finance-tracking/#/',
+  goal: '/finance-tracking/#/goal',
+  goalDetail: (id: number | string) => `/finance-tracking/#/goal/${id}`,
+  netWorth: '/finance-tracking/#/net-worth',
+  allocation: '/finance-tracking/#/net-worth/allocation',
+  budget: '/finance-tracking/#/budget',
+} as const


### PR DESCRIPTION
Closes #151. Sub-issue of #62.

## Summary
22 E2E tests for Home Dashboard cross-page integration:
- Flow 1: Budget → Goals projection (5 tests)
- Flow 2: Balances → Home widgets (5 tests)
- Flow 4: Balances → Goal progress (4 tests)
- Edge cases (3 tests)
- Additional cross-page integration (5 tests)

## Verification
- 66/66 with `--repeat-each=3`
- Full E2E: 304/305 (1 pre-existing flake unrelated, passes in isolation)
- All 5 anti-pattern greps empty
- HEAD: `73cc94d`

## New shared infra
`e2e/fixtures/cross-page-data.ts` (336 lines) — 13-key seed, mutate helpers, v2 export builder. Reusable by #152/#153/#154.

## Adaptations documented inline
- **A.** Tests 2/33: "Add budget data →" is a plain `<span>` in GoalsPeek (no click handler). Tests verify text + class only. Follow-up: **#160**.
- **B.** Test 47: Home cards lack per-card ErrorBoundary. Test verifies cross-page isolation + page-level boundary instead of per-card. Follow-up: **#161**.
- C–G: minor seed/event/listener adaptations, all documented inline.

## Follow-ups filed
- #160 — GoalsPeek: actionable "Add budget data →" link
- #161 — Wrap each Home card in `<ErrorBoundary variant="card">`

## Reviewers
@dutta14 — Alex (architect) and Casey (QA) review next.