### PR TITLE
fix(design): symmetric mobile modal radius (#37) + vertical picker entrance (#38)

### DIFF
--- a/src/pages/goal/components/TemplatePicker.test.tsx
+++ b/src/pages/goal/components/TemplatePicker.test.tsx
@@ -75,3 +75,43 @@ describe('TemplatePicker', () => {
     }
   })
 })
+
+describe('TemplatePicker motion', () => {
+  it('TemplatePicker.css uses picker-reveal animation, not wizard-fade', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const cssPath = path.resolve(__dirname, '..', '..', '..', 'styles', 'TemplatePicker.css')
+    const source = fs.readFileSync(cssPath, 'utf-8')
+    expect(source).toMatch(/\.template-picker\s*\{[^}]*animation:\s*picker-reveal\s+0\.2s\s+ease/)
+    expect(source).not.toContain('wizard-fade')
+  })
+
+  it('Goal.css declares the picker-reveal keyframes with vertical translation', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const cssPath = path.resolve(__dirname, '..', '..', '..', 'styles', 'Goal.css')
+    const source = fs.readFileSync(cssPath, 'utf-8')
+    expect(source).toMatch(/@keyframes\s+picker-reveal\s*\{[\s\S]*translateY\(-4px\)[\s\S]*translateY\(0\)[\s\S]*\}/)
+  })
+
+  it('Goal.css disables the picker animation under prefers-reduced-motion', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const cssPath = path.resolve(__dirname, '..', '..', '..', 'styles', 'Goal.css')
+    const source = fs.readFileSync(cssPath, 'utf-8')
+    const reducedMotionBlock = source.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\n\}/)
+    expect(reducedMotionBlock).not.toBeNull()
+    const block = reducedMotionBlock![0]
+    const coversPicker =
+      /\*\s*\{[^}]*animation:\s*none/.test(block) || /\.template-picker[\s\S]*animation:\s*none/.test(block)
+    expect(coversPicker).toBe(true)
+  })
+
+  it('Goal.css preserves wizard-fade for wizard step transitions', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const cssPath = path.resolve(__dirname, '..', '..', '..', 'styles', 'Goal.css')
+    const source = fs.readFileSync(cssPath, 'utf-8')
+    expect(source).toMatch(/@keyframes\s+wizard-fade/)
+  })
+})

--- a/src/styles/Goal.css
+++ b/src/styles/Goal.css
@@ -994,6 +994,17 @@ body.dark .goal-drag-item--long-press {
   }
 }
 
+@keyframes picker-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .wizard-step,
   .template-picker {

--- a/src/styles/GoalFormModal.css
+++ b/src/styles/GoalFormModal.css
@@ -62,6 +62,6 @@
   .goal-form-modal {
     max-width: 100%;
     max-height: 92vh;
-    border-radius: var(--radius) 1rem 0 0;
+    border-radius: 1rem 1rem 0 0;
   }
 }

--- a/src/styles/TemplatePicker.css
+++ b/src/styles/TemplatePicker.css
@@ -1,7 +1,7 @@
 /* Template Picker */
 .template-picker {
   margin-top: 1rem;
-  animation: wizard-fade 0.2s ease;
+  animation: picker-reveal 0.2s ease;
 }
 
 .template-picker-header {


### PR DESCRIPTION
Two small CSS fixes from the v0.6 Design Polish milestone, combined.

## #37 — Symmetric mobile modal radius (P2)
`src/styles/GoalFormModal.css:65` — inside `@media (max-width: 640px)`, change `border-radius: var(--radius) 1rem 0 0` → `border-radius: 1rem 1rem 0 0`. The bottom-sheet pattern had 8px on the left and 16px on the right; uniform 16px reads correctly.

## #38 — Vertical picker entrance (P3)
- `src/styles/TemplatePicker.css:4` — `animation: wizard-fade` → `animation: picker-reveal`.
- `src/styles/Goal.css` — add `@keyframes picker-reveal` (`translateY(-4px) → 0`) next to `wizard-fade`. The picker is a vertical disclosure beneath its trigger; the entrance now matches that relationship.
- `wizard-fade` is preserved — still used by wizard step transitions.
- Existing `@media (prefers-reduced-motion: reduce)` block in `Goal.css` already lists `.template-picker`, so no change needed there.

## Tests
`src/pages/goal/components/TemplatePicker.test.tsx` — 4 new file-read assertions matching the existing pattern in `GoalDetail.test.tsx`:
1. `.template-picker` rule references `picker-reveal` and no longer references `wizard-fade`.
2. `@keyframes picker-reveal` declared in `Goal.css` with vertical translation.
3. `prefers-reduced-motion: reduce` block covers the picker.
4. `wizard-fade` keyframes preserved.

## Verification
- `npm run lint` — clean
- `npx vitest run` — 2691/2691 pass (131 files)
- `npm run build` — succeeds
- `npx tsc --noEmit` — pre-existing errors in `src/utils/crypto.ts` and `src/utils/importValidator.ts` confirmed on `main`; out of scope.

Fixes #37
Fixes #38