### PR TITLE
fix(design): dark-mode budget dropdown text (#157) + date picker icon (#158)

### DIFF
--- a/src/pages/budget/components/BudgetTable.test.tsx
+++ b/src/pages/budget/components/BudgetTable.test.tsx
@@ -953,3 +953,13 @@ describe('BudgetTable', () => {
     })
   })
 })
+
+describe('Budget.css dark mode', () => {
+  it('.budget-filter-item declares color: var(--color-text) so dropdown labels are readable in dark mode', async () => {
+    const fs = await import('fs')
+    const path = await import('path')
+    const cssPath = path.resolve(__dirname, '..', '..', '..', 'styles', 'Budget.css')
+    const source = fs.readFileSync(cssPath, 'utf-8')
+    expect(source).toMatch(/\.budget-filter-item\s*\{[^}]*color:\s*var\(--color-text\)\s*;[^}]*\}/)
+  })
+})

--- a/src/styles/Budget.css
+++ b/src/styles/Budget.css
@@ -792,6 +792,7 @@ body.dark .budget-confirm-newcat-btn--no {
   gap: 0.5rem;
   padding: 0.3rem 0.6rem;
   font-size: var(--fs-sm);
+  color: var(--color-text);
   cursor: pointer;
   transition: background 0.1s;
 }

--- a/src/styles/colorThemes.css
+++ b/src/styles/colorThemes.css
@@ -121,3 +121,12 @@ body.dark {
   --color-positive-border: #064e3b;
   --color-tooltip-bg: #1e2228;
 }
+
+/* Dark-mode native control overrides */
+body.dark input[type='date']::-webkit-calendar-picker-indicator,
+body.dark input[type='datetime-local']::-webkit-calendar-picker-indicator,
+body.dark input[type='month']::-webkit-calendar-picker-indicator,
+body.dark input[type='time']::-webkit-calendar-picker-indicator {
+  filter: invert(1) brightness(1.2);
+  cursor: pointer;
+}

--- a/src/styles/colorThemes.test.ts
+++ b/src/styles/colorThemes.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+describe('colorThemes.css dark mode native control overrides', () => {
+  const cssPath = path.resolve(__dirname, 'colorThemes.css')
+  const source = fs.readFileSync(cssPath, 'utf-8')
+
+  it('inverts the webkit calendar picker indicator under body.dark for date/datetime-local/month/time inputs', () => {
+    const block = source.match(
+      /body\.dark input\[type='date'\]::-webkit-calendar-picker-indicator[\s\S]*?\{[\s\S]*?filter:\s*invert\(1\)\s*brightness\(1\.2\)[\s\S]*?\}/,
+    )
+    expect(block).not.toBeNull()
+    const text = block![0]
+    expect(text).toContain("input[type='date']::-webkit-calendar-picker-indicator")
+    expect(text).toContain("input[type='datetime-local']::-webkit-calendar-picker-indicator")
+    expect(text).toContain("input[type='month']::-webkit-calendar-picker-indicator")
+    expect(text).toContain("input[type='time']::-webkit-calendar-picker-indicator")
+    expect(text).toMatch(/cursor:\s*pointer/)
+  })
+})


### PR DESCRIPTION
## Summary

Two surgical dark-mode CSS fixes. CSS-only + tests, no source code changes.

### #157 — Budget category dropdown text unreadable in dark mode

`src/styles/Budget.css` L789-798: `.budget-filter-item` declared no `color`, so the dropdown labels ("All Categories", "Dividends", etc.) inherited a near-black color and were unreadable on the dark dropdown surface. Added `color: var(--color-text);` to the base rule. The `:hover` rule only sets `background: var(--color-surface-hover)`, so the inherited color from the base rule now applies cleanly on hover too.

**Sweep result:** all sibling dropdown patterns (`.budget-upload-menu-item`, `.goal-actions-menu-item`, `.card-context-menu-item`, `.data-th-filter-option`) explicitly declare a `color`. `.budget-filter-item` was the only offender. No follow-up needed.

### #158 — Date input calendar picker icon invisible in dark mode

`src/styles/colorThemes.css` (appended): added a `body.dark` rule that applies `filter: invert(1) brightness(1.2)` to `::-webkit-calendar-picker-indicator` for `date`, `datetime-local`, `month`, and `time` inputs. `colorThemes.css` is the canonical home for dark-mode overrides per repo conventions and is already imported in `src/App.tsx` L29.

## Tests

Following the file-read + regex pattern established by PR #177 (TemplatePicker.test.tsx motion block).

- `src/pages/budget/components/BudgetTable.test.tsx` — new `describe('Budget.css dark mode')` block asserting `.budget-filter-item` declares `color: var(--color-text)`.
- `src/styles/colorThemes.test.ts` (new) — asserts the four `::-webkit-calendar-picker-indicator` selectors exist under `body.dark` with the correct filter and `cursor: pointer`.

## Verification

- `npm run lint` → clean
- `npx vitest run` → 132 files, 2693 tests passing
- `npm run build` → succeeds (no new warnings)
- `tsc --noEmit` skipped per task scope (pre-existing errors on main, tracked by #177 context)

Fixes #157
Fixes #158