### PR TITLE
chore: add TypeScript typecheck gate (#185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm audit --audit-level=high
       - run: npx prettier --check 'src/**/*.{ts,tsx,css}'
       - run: npx eslint src/ --max-warnings=0
+      - run: npx tsc --noEmit
       - run: npx vitest run
       - run: npm run build
       - name: Configure Pages

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 npm audit --audit-level=high
 npx prettier --check src/
 npx eslint src/ --max-warnings=0
+npx tsc --noEmit
 npx vitest run --coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,7 @@ Custom DOM events for cross-component communication:
 | `npm run lint:fix`      | ESLint auto-fix                            |
 | `npm run format`        | Prettier write                             |
 | `npm run format:check`  | Prettier check (used in CI)                |
+| `npm run typecheck`     | TypeScript check (used in CI and pre-push) |
 
 ## Contexts
 
@@ -233,7 +234,8 @@ Runs automatically before each commit:
 1. `npm audit --audit-level=high`
 2. `npx prettier --check src/`
 3. `npx eslint src/ --max-warnings=0`
-4. `npx vitest run`
+4. `npx tsc --noEmit`
+5. `npx vitest run`
 
 ### Deployment
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "audit": "npm audit --audit-level=high",
     "test": "vitest",
     "test:run": "vitest run",
+    "typecheck": "tsc --noEmit",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/src/contexts/EncryptionContext.tsx
+++ b/src/contexts/EncryptionContext.tsx
@@ -47,7 +47,7 @@ function readEnabled(): boolean {
   return localStorage.getItem(LS_ENABLED) === '1'
 }
 
-function readSalt(): Uint8Array | null {
+function readSalt(): Uint8Array<ArrayBuffer> | null {
   const raw = localStorage.getItem(LS_SALT)
   if (!raw) return null
   try {

--- a/src/contexts/GitHubSyncContext.test.tsx
+++ b/src/contexts/GitHubSyncContext.test.tsx
@@ -296,7 +296,7 @@ describe('GitHubSyncContext', () => {
               status: 'active',
               goalType: 'fi',
               nature: 'asset',
-              allocation: { usEquity: 80, intlEquity: 20, usBond: 0, intlBond: 0, cash: 0, other: 0 },
+              allocation: 'us-stock',
             },
           ],
           [{ id: 1, accountId: 1, month: '2025-01', balance: 50000 }],
@@ -724,7 +724,7 @@ describe('GitHubSyncContext', () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const { result } = renderHook(() => useGitHubSyncContext(), { wrapper })
 
-      let capturedProgress: typeof result.current.syncProgress = null
+      let capturedProgress = null as typeof result.current.syncProgress
       act(() => {
         result.current.handleSyncNow({}, undefined, true)
         capturedProgress = result.current.syncProgress

--- a/src/contexts/ImportExportContext.test.tsx
+++ b/src/contexts/ImportExportContext.test.tsx
@@ -198,17 +198,18 @@ describe('ImportExportContext', () => {
       createElementSpy = vi.spyOn(document, 'createElement')
       createElementSpy.mockImplementation((tag: string) => {
         if (tag === 'a') {
-          return {
+          const anchor = {
             _href: '',
             download: '',
             click: vi.fn(),
             set href(v: string) {
-              this._href = v
+              anchor._href = v
             },
             get href() {
-              return this._href
+              return anchor._href
             },
-          } as unknown as HTMLAnchorElement
+          }
+          return anchor as unknown as HTMLAnchorElement
         }
         return origCreateElement(tag)
       })
@@ -275,24 +276,25 @@ describe('ImportExportContext', () => {
       createElementSpy = vi.spyOn(document, 'createElement')
       createElementSpy.mockImplementation((tag: string) => {
         if (tag === 'a') {
-          return {
+          const anchor = {
             _href: '',
             _download: '',
             click: vi.fn(),
             set href(v: string) {
-              this._href = v
+              anchor._href = v
             },
             get href() {
-              return this._href
+              return anchor._href
             },
             set download(v: string) {
-              this._download = v
+              anchor._download = v
               capturedDownload = v
             },
             get download() {
-              return this._download
+              return anchor._download
             },
-          } as unknown as HTMLAnchorElement
+          }
+          return anchor as unknown as HTMLAnchorElement
         }
         return origCreateElement(tag)
       })
@@ -606,17 +608,18 @@ describe('ImportExportContext', () => {
       const createElementSpy = vi.spyOn(document, 'createElement')
       createElementSpy.mockImplementation((tag: string) => {
         if (tag === 'a') {
-          return {
+          const anchor = {
             _href: '',
             download: '',
             click: vi.fn(),
             set href(v: string) {
-              this._href = v
+              anchor._href = v
             },
             get href() {
-              return this._href
+              return anchor._href
             },
-          } as unknown as HTMLAnchorElement
+          }
+          return anchor as unknown as HTMLAnchorElement
         }
         return origCreateElement(tag)
       })

--- a/src/contexts/TaxSyncContext.tsx
+++ b/src/contexts/TaxSyncContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useCallback, useEffect, useRef, useMemo, FC,
 import { useGitHubSyncContext } from './GitHubSyncContext'
 import { useEncryption } from './EncryptionContext'
 import { syncAllTaxFiles } from '../pages/taxes/taxGitHubSync'
+import { EMPTY_STORE, TaxStore } from '../pages/taxes/types'
 import { appStorage } from '../utils/appStorage'
 
 export interface TaxSyncContextValue {
@@ -53,7 +54,7 @@ export const TaxSyncProvider: FC<{ children: ReactNode }> = ({ children }) => {
       queueMicrotask(() => markDirty('taxes'))
       if (timer) clearTimeout(timer)
       timer = setTimeout(async () => {
-        const taxStore = appStorage.getJSON('tax-store', {})
+        const taxStore = appStorage.getJSON<TaxStore>('tax-store', EMPTY_STORE)
         const taxesPayload = {
           version: 1,
           exportedAt: new Date().toISOString(),
@@ -85,7 +86,7 @@ export const TaxSyncProvider: FC<{ children: ReactNode }> = ({ children }) => {
       }
       await syncTaxesNow(taxesPayload, message ? `Taxes: ${message}` : undefined)
       if (isConfiguredRef.current && tokenRef.current) {
-        const taxStore = appStorage.getJSON('tax-store', {})
+        const taxStore = appStorage.getJSON<TaxStore>('tax-store', EMPTY_STORE)
         await syncAllTaxFiles(configRef.current, tokenRef.current, taxStore, cryptoKey).catch(e =>
           console.error('Tax file sync error:', e),
         )

--- a/src/flags/flags.test.tsx
+++ b/src/flags/flags.test.tsx
@@ -9,7 +9,7 @@ import { useFlag } from './useFlag'
 
 /* ── Mock GitHubSyncContext ───────────────────────────────────────── */
 
-const mockActiveToken = vi.fn(() => 'test-token')
+const mockActiveToken = vi.fn<() => string | null>(() => 'test-token')
 
 vi.mock('../contexts/GitHubSyncContext', () => ({
   useGitHubSyncContext: () => ({
@@ -97,7 +97,8 @@ describe('FlagContext resolution', () => {
   })
 
   it('returns default when no override or rollout config', () => {
-    const resolveFlag = (_flag: Parameters<FlagContextValue['resolveFlag']>[0]) => _flag.default
+    const resolveFlag = ((_flag: Parameters<FlagContextValue['resolveFlag']>[0]) =>
+      _flag.default) as FlagContextValue['resolveFlag']
 
     const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
       <FlagContext.Provider
@@ -450,9 +451,17 @@ describe('FlagProvider integration', () => {
       <FlagContext.Provider
         value={{
           resolveFlag: resolveFlag as FlagContextValue['resolveFlag'],
+          overrides: {},
+          rolloutConfig: { version: 1, updatedAt: '', flags: {} },
           setOverride: () => {},
           resetAllOverrides: () => {},
+          saveRolloutConfig: async () => {},
+          refresh: async () => {},
           isAdmin: true,
+          isLoading: false,
+          error: null,
+          environment: 'staging' as const,
+          clientId: 'test',
         }}
       >
         {children}
@@ -481,9 +490,17 @@ describe('FlagProvider integration', () => {
       <FlagContext.Provider
         value={{
           resolveFlag: resolveFlag as FlagContextValue['resolveFlag'],
+          overrides: {},
+          rolloutConfig: { version: 1, updatedAt: '', flags: {} },
           setOverride: () => {},
           resetAllOverrides: () => {},
+          saveRolloutConfig: async () => {},
+          refresh: async () => {},
           isAdmin: true,
+          isLoading: false,
+          error: null,
+          environment: 'staging' as const,
+          clientId: 'test',
         }}
       >
         {children}
@@ -535,9 +552,17 @@ describe('FlagProvider integration', () => {
       <FlagContext.Provider
         value={{
           resolveFlag: resolveFlag as FlagContextValue['resolveFlag'],
+          overrides: {},
+          rolloutConfig: { version: 1, updatedAt: '', flags: {} },
           setOverride: () => {},
           resetAllOverrides: () => {},
+          saveRolloutConfig: async () => {},
+          refresh: async () => {},
           isAdmin: true,
+          isLoading: false,
+          error: null,
+          environment: 'staging' as const,
+          clientId: 'test',
         }}
       >
         {children}

--- a/src/hooks/useGitHubSync.test.ts
+++ b/src/hooks/useGitHubSync.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { setStorageItem } from '../utils/storage'
 import { loadConfig, toBase64, fromBase64, useGitHubSync } from './useGitHubSync'
-import type { GitHubSyncConfig } from './useGitHubSync'
+import type { GitHubSyncConfig, RestoreResult } from './useGitHubSync'
 
 describe('toBase64 / fromBase64', () => {
   it('round-trips ASCII text', () => {
@@ -693,7 +693,7 @@ describe('useGitHubSync hook', () => {
         headers: new Headers(),
       } as Response)
 
-      let res = { ok: false, message: '', data: undefined as unknown }
+      let res: RestoreResult = { ok: false, message: '', data: undefined }
       await act(async () => {
         res = await result.current.restoreLatest()
       })
@@ -772,7 +772,7 @@ describe('useGitHubSync hook', () => {
         headers: new Headers(),
       } as Response)
 
-      let res = { ok: false, message: '', data: undefined as unknown }
+      let res: RestoreResult = { ok: false, message: '', data: undefined }
       await act(async () => {
         res = await result.current.restoreFromCommit('abc1234567890')
       })
@@ -875,7 +875,7 @@ describe('useGitHubSync hook', () => {
         headers: new Headers(),
       } as Response)
 
-      let res = { ok: false, data: undefined as unknown }
+      let res: RestoreResult = { ok: false, message: '', data: undefined }
       await act(async () => {
         res = await result.current.restoreDataLatest()
       })
@@ -911,7 +911,7 @@ describe('useGitHubSync hook', () => {
         headers: new Headers(),
       } as Response)
 
-      let res = { ok: false, data: undefined as unknown }
+      let res: { ok: boolean; data?: unknown } = { ok: false, data: undefined }
       await act(async () => {
         res = await result.current.restoreToolsLatest()
       })
@@ -960,7 +960,7 @@ describe('useGitHubSync hook', () => {
         headers: new Headers(),
       } as Response)
 
-      let res = { ok: false, data: undefined as unknown }
+      let res: RestoreResult = { ok: false, message: '', data: undefined }
       await act(async () => {
         res = await result.current.restoreTaxesLatest()
       })
@@ -1467,7 +1467,7 @@ describe('useGitHubSync hook', () => {
         json: () => Promise.resolve({ content }),
         headers: new Headers(),
       } as Response)
-      let res = { ok: false, data: undefined as unknown }
+      let res: { ok: boolean; data?: unknown } = { ok: false, data: undefined }
       await act(async () => {
         res = await result.current.restoreAllocationLatest()
       })
@@ -1639,7 +1639,7 @@ describe('useGitHubSync hook', () => {
         json: () => Promise.resolve({ content, encoding: 'base64' }),
         headers: new Headers(),
       } as Response)
-      let res = { ok: false, data: undefined as unknown, message: '' }
+      let res: RestoreResult = { ok: false, data: undefined, message: '' }
       await act(async () => {
         res = await result.current.restoreDataLatest()
       })

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -545,20 +545,20 @@ export const useGitHubSync = () => {
     [activeToken, apiHeaders, config.owner, config.repo, taxesFilePath, getFileShaForPath, isConfigured, clearDirty],
   )
 
-  const restoreTaxesLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
-    if (!isConfigured) return { ok: false }
+  const restoreTaxesLatest = useCallback(async (): Promise<RestoreResult> => {
+    if (!isConfigured) return { ok: false, message: '' }
     try {
       const res = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}/contents/${taxesFilePath}`, {
         headers: apiHeaders(activeToken),
       })
-      if (res.status === 404) return { ok: false }
-      if (!res.ok) return { ok: false }
+      if (res.status === 404) return { ok: false, message: '' }
+      if (!res.ok) return { ok: false, message: '' }
       const json = await res.json()
-      if (typeof json.content !== 'string') return { ok: false }
+      if (typeof json.content !== 'string') return { ok: false, message: '' }
       const parsed = JSON.parse(atob(json.content.replace(/\n/g, '')))
-      return { ok: true, data: parsed }
+      return { ok: true, message: '', data: parsed }
     } catch {
-      return { ok: false }
+      return { ok: false, message: '' }
     }
   }, [activeToken, apiHeaders, taxesFilePath, config.owner, config.repo, isConfigured])
 

--- a/src/hooks/useProfile.test.ts
+++ b/src/hooks/useProfile.test.ts
@@ -69,15 +69,15 @@ describe('Profile loading logic', () => {
 describe('useProfile cross-tab sync', () => {
   let subscribeSpy: ReturnType<typeof vi.spyOn>
   let capturedCallback: ((value: string | null) => void) | undefined
-  let unsub: ReturnType<typeof vi.fn>
+  let unsub: ReturnType<typeof vi.fn<() => void>>
 
   beforeEach(() => {
     localStorage.clear()
     capturedCallback = undefined
-    unsub = vi.fn()
+    unsub = vi.fn(() => undefined)
     subscribeSpy = vi.spyOn(appStorage, 'subscribe').mockImplementation((key, cb) => {
       if (key === 'user-profile') capturedCallback = cb
-      return unsub
+      return () => unsub()
     })
   })
 

--- a/src/pages/allocation/hooks/useCustomRatios.test.ts
+++ b/src/pages/allocation/hooks/useCustomRatios.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../../utils/appStorage', () => {
 import { appStorage } from '../../../utils/appStorage'
 import { STORAGE_KEY } from '../constants'
 import type { CustomRatio, RatioPreset } from '../types'
+import type { AssetAllocation } from '../../data/types'
 
 function getStored(): CustomRatio[] {
   return appStorage.getJSON<CustomRatio[]>(STORAGE_KEY, [])
@@ -448,7 +449,7 @@ describe('useCustomRatios', () => {
     })
 
     it('does not add a group when already at 6 groups', () => {
-      const groups = Array.from({ length: 6 }, (_, i) => ({ label: `G${i}`, classes: [] as string[] }))
+      const groups = Array.from({ length: 6 }, (_, i) => ({ label: `G${i}`, classes: [] as AssetAllocation[] }))
       seedStorage([{ id: 'r1', name: 'R', scope: 'total', groups }])
       const { result } = renderHook(() => useCustomRatios())
       act(() => result.current.addGroup())

--- a/src/pages/allocation/hooks/useCustomRatios.ts
+++ b/src/pages/allocation/hooks/useCustomRatios.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { Scope, CustomRatio, RatioPreset, RatioGoal } from '../types'
+import { AssetAllocation } from '../../data/types'
 import { loadCustomRatios, saveCustomRatios, makeDefaultRatio, makeId } from '../utils'
 
 export function useCustomRatios() {

--- a/src/pages/budget/Budget.test.tsx
+++ b/src/pages/budget/Budget.test.tsx
@@ -3,13 +3,14 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import Budget from './Budget'
+import type { BudgetViewMode } from './types'
 
 /* ─── Mocks ─── */
 
 const mockUseBudget = {
   selectedYear: 2025,
   setSelectedYear: vi.fn(),
-  viewMode: 'aggregated' as const,
+  viewMode: 'aggregated' as BudgetViewMode,
   setViewMode: vi.fn(),
   uploadCSV: vi.fn(),
   removeCSV: vi.fn(),

--- a/src/pages/budget/components/BudgetTable.test.tsx
+++ b/src/pages/budget/components/BudgetTable.test.tsx
@@ -13,7 +13,7 @@ beforeEach(() => {
 
 const defaultProps = () => ({
   year: 2025,
-  type: 'expense' as const,
+  type: 'expense' as 'income' | 'expense',
   categoryGroups: [
     makeCategoryGroup({ id: 'essentials', name: 'Essentials', categories: ['Groceries', 'Rent'] }),
     makeCategoryGroup({ id: 'lifestyle', name: 'Lifestyle', categories: ['Dining', 'Entertainment'] }),

--- a/src/pages/budget/components/CSVPreviewModal.test.tsx
+++ b/src/pages/budget/components/CSVPreviewModal.test.tsx
@@ -148,7 +148,7 @@ describe('CSVPreviewModal', () => {
     await user.click(screen.getByText('Import (3 of 4 columns)'))
 
     expect(props.onConfirm).toHaveBeenCalledOnce()
-    const result = props.onConfirm.mock.calls[0][0]
+    const result = (props.onConfirm as ReturnType<typeof vi.fn>).mock.calls[0][0]
     const lines = result.split('\n')
     expect(lines[0]).toBe('Date,Category,Amount')
     expect(lines[1]).toContain('Groceries')

--- a/src/pages/budget/components/CashflowBarChart.tsx
+++ b/src/pages/budget/components/CashflowBarChart.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react'
+import { ComponentProps, FC, useMemo } from 'react'
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, ReferenceLine, CartesianGrid, Cell } from 'recharts'
 import { Transaction, TimePeriod } from '../types'
 
@@ -108,11 +108,15 @@ const CashflowBarChart: FC<CashflowBarChartProps> = ({
             width={55}
           />
           <Tooltip
-            formatter={(value: number, name: string) => [
-              fmt(Math.abs(value)),
-              name === 'income' ? 'Income' : 'Expense',
-            ]}
-            labelFormatter={(label: string) => `${label} ${year}`}
+            formatter={
+              ((value: number, name: string) => [
+                fmt(Math.abs(value)),
+                name === 'income' ? 'Income' : 'Expense',
+              ]) as unknown as ComponentProps<typeof Tooltip>['formatter']
+            }
+            labelFormatter={
+              ((label: string) => `${label} ${year}`) as unknown as ComponentProps<typeof Tooltip>['labelFormatter']
+            }
             contentStyle={{ fontSize: '0.82rem', borderRadius: 8 }}
           />
           <ReferenceLine y={0} stroke="var(--cashflow-zero, #9ca3af)" strokeWidth={1} />

--- a/src/pages/budget/components/CategoryGroupManager.test.tsx
+++ b/src/pages/budget/components/CategoryGroupManager.test.tsx
@@ -72,7 +72,7 @@ describe('CategoryGroupManager', () => {
     expect(screen.getByText('Groceries')).toBeInTheDocument()
 
     // Click the first toggle (Essentials)
-    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')!
+    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')! as HTMLElement
     const toggle = within(essentialsGroup).getAllByRole('button')[0]
     await user.click(toggle)
 
@@ -84,7 +84,7 @@ describe('CategoryGroupManager', () => {
     const user = userEvent.setup()
     render(<CategoryGroupManager {...defaultProps} />)
 
-    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')!
+    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')! as HTMLElement
     const toggle = within(essentialsGroup).getAllByRole('button')[0]
 
     // Collapse
@@ -157,19 +157,19 @@ describe('CategoryGroupManager', () => {
   it('does not show rename/delete/move buttons for protected groups', () => {
     render(<CategoryGroupManager {...defaultProps} />)
 
-    const othersGroup = screen.getByText('Others').closest('.budget-group-block')!
+    const othersGroup = screen.getByText('Others').closest('.budget-group-block')! as HTMLElement
     expect(within(othersGroup).queryByTitle('Rename group')).not.toBeInTheDocument()
     expect(within(othersGroup).queryByTitle('Delete group (categories move to Others)')).not.toBeInTheDocument()
     expect(within(othersGroup).queryByTitle('Move group up')).not.toBeInTheDocument()
 
-    const removedGroup = screen.getByText('Removed').closest('.budget-group-block')!
+    const removedGroup = screen.getByText('Removed').closest('.budget-group-block')! as HTMLElement
     expect(within(removedGroup).queryByTitle('Rename group')).not.toBeInTheDocument()
   })
 
   it('shows rename/delete/move buttons for non-protected groups', () => {
     render(<CategoryGroupManager {...defaultProps} />)
 
-    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')!
+    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')! as HTMLElement
     expect(within(essentialsGroup).getByTitle('Rename group')).toBeInTheDocument()
     expect(within(essentialsGroup).getByTitle('Delete group (categories move to Others)')).toBeInTheDocument()
     expect(within(essentialsGroup).getByTitle('Move group up')).toBeInTheDocument()
@@ -181,7 +181,7 @@ describe('CategoryGroupManager', () => {
     const user = userEvent.setup()
     render(<CategoryGroupManager {...defaultProps} onUpdate={onUpdate} />)
 
-    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')!
+    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')! as HTMLElement
     const deleteBtn = within(essentialsGroup).getByTitle('Delete group (categories move to Others)')
     await user.click(deleteBtn)
 
@@ -255,7 +255,7 @@ describe('CategoryGroupManager', () => {
     render(<CategoryGroupManager {...defaultProps} categoryHasTransactions={categoryHasTransactions} />)
 
     // Click the delete button on Groceries
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
     const deleteBtn = within(groceriesEl).getByTitle('Delete category')
     await user.click(deleteBtn)
 
@@ -269,7 +269,7 @@ describe('CategoryGroupManager', () => {
     const user = userEvent.setup()
     render(<CategoryGroupManager {...defaultProps} onDeleteCategory={onDeleteCategory} />)
 
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
     const deleteBtn = within(groceriesEl).getByTitle('Delete category')
     await user.click(deleteBtn)
 
@@ -373,7 +373,7 @@ describe('CategoryGroupManager', () => {
     const user = userEvent.setup()
     render(<CategoryGroupManager {...defaultProps} />)
 
-    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')!
+    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')! as HTMLElement
     const renameBtn = within(essentialsGroup).getByTitle('Rename group')
     await user.click(renameBtn)
 
@@ -387,7 +387,7 @@ describe('CategoryGroupManager', () => {
     const user = userEvent.setup()
     render(<CategoryGroupManager {...defaultProps} onUpdate={onUpdate} />)
 
-    const lifestyleGroup = screen.getByText('Lifestyle').closest('.budget-group-block')!
+    const lifestyleGroup = screen.getByText('Lifestyle').closest('.budget-group-block')! as HTMLElement
     const moveUpBtn = within(lifestyleGroup).getByTitle('Move group up')
     await user.click(moveUpBtn)
 
@@ -402,7 +402,7 @@ describe('CategoryGroupManager', () => {
     const user = userEvent.setup()
     render(<CategoryGroupManager {...defaultProps} onUpdate={onUpdate} />)
 
-    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')!
+    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')! as HTMLElement
     const moveDownBtn = within(essentialsGroup).getByTitle('Move group down')
     await user.click(moveDownBtn)
 
@@ -423,7 +423,7 @@ describe('CategoryGroupManager', () => {
     ]
     render(<CategoryGroupManager {...defaultProps} groups={groups} onUpdate={onUpdate} />)
 
-    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')!
+    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')! as HTMLElement
     const moveDownBtn = within(essentialsGroup).getByTitle('Move group down')
     await user.click(moveDownBtn)
 
@@ -440,8 +440,8 @@ describe('CategoryGroupManager', () => {
     const onUpdate = vi.fn()
     render(<CategoryGroupManager {...defaultProps} onUpdate={onUpdate} />)
 
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
-    const lifestyleGroup = screen.getByText('Lifestyle').closest('.budget-group-block')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
+    const lifestyleGroup = screen.getByText('Lifestyle').closest('.budget-group-block')! as HTMLElement
 
     fireEvent.dragStart(groceriesEl, { dataTransfer: { setData: vi.fn(), effectAllowed: '' } })
     fireEvent.dragOver(lifestyleGroup, { dataTransfer: { dropEffect: '' } })
@@ -461,8 +461,8 @@ describe('CategoryGroupManager', () => {
     const onUpdate = vi.fn()
     render(<CategoryGroupManager {...defaultProps} onUpdate={onUpdate} />)
 
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
-    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
+    const essentialsGroup = screen.getByText('Essentials').closest('.budget-group-block')! as HTMLElement
 
     fireEvent.dragStart(groceriesEl, { dataTransfer: { setData: vi.fn(), effectAllowed: '' } })
     fireEvent.dragOver(essentialsGroup, { dataTransfer: { dropEffect: '' } })
@@ -474,7 +474,7 @@ describe('CategoryGroupManager', () => {
   it('resets drag state on drag end', () => {
     render(<CategoryGroupManager {...defaultProps} />)
 
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
     fireEvent.dragStart(groceriesEl, { dataTransfer: { setData: vi.fn(), effectAllowed: '' } })
     fireEvent.dragEnd(groceriesEl)
 
@@ -485,8 +485,8 @@ describe('CategoryGroupManager', () => {
   it('clears drag-over highlight on drag leave', () => {
     render(<CategoryGroupManager {...defaultProps} />)
 
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
-    const lifestyleGroup = screen.getByText('Lifestyle').closest('.budget-group-block')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
+    const lifestyleGroup = screen.getByText('Lifestyle').closest('.budget-group-block')! as HTMLElement
 
     fireEvent.dragStart(groceriesEl, { dataTransfer: { setData: vi.fn(), effectAllowed: '' } })
     fireEvent.dragOver(lifestyleGroup, { dataTransfer: { dropEffect: '' } })
@@ -508,7 +508,7 @@ describe('CategoryGroupManager', () => {
   it('shows "Drop here" in empty group when dragging a category', () => {
     render(<CategoryGroupManager {...defaultProps} />)
 
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
     fireEvent.dragStart(groceriesEl, { dataTransfer: { setData: vi.fn(), effectAllowed: '' } })
 
     // Empty groups should show "Drop here" instead of "No categories"
@@ -549,7 +549,7 @@ describe('CategoryGroupManager', () => {
     await user.click(screen.getByText('Merge Categories'))
 
     // Click the category item (not the dropdown option)
-    const groceriesCat = screen.getByText('Groceries').closest('.budget-group-cat')!
+    const groceriesCat = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
     await user.click(groceriesCat)
     expect(screen.getByText(/1 selected/)).toBeInTheDocument()
 
@@ -594,7 +594,7 @@ describe('CategoryGroupManager', () => {
     )
 
     // Delete Groceries (has transactions)
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
     await user.click(within(groceriesEl).getByTitle('Delete category'))
 
     // Select target from dropdown
@@ -612,7 +612,7 @@ describe('CategoryGroupManager', () => {
     const user = userEvent.setup()
     render(<CategoryGroupManager {...defaultProps} categoryHasTransactions={categoryHasTransactions} />)
 
-    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')!
+    const groceriesEl = screen.getByText('Groceries').closest('.budget-group-cat')! as HTMLElement
     await user.click(within(groceriesEl).getByTitle('Delete category'))
 
     expect(screen.getByText(/has transactions/)).toBeInTheDocument()

--- a/src/pages/budget/hooks/useBudget.test.ts
+++ b/src/pages/budget/hooks/useBudget.test.ts
@@ -748,9 +748,9 @@ describe('useBudget — viewMode', () => {
   it('switches view mode', () => {
     const { result } = renderHook(() => useBudget())
     act(() => {
-      result.current.setViewMode('monthly')
+      result.current.setViewMode('detailed')
     })
-    expect(result.current.viewMode).toBe('monthly')
+    expect(result.current.viewMode).toBe('detailed')
   })
 })
 

--- a/src/pages/budget/utils/budgetGitHubSync.test.ts
+++ b/src/pages/budget/utils/budgetGitHubSync.test.ts
@@ -32,7 +32,7 @@ let fetchMock: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   fetchMock = vi.fn()
-  global.fetch = fetchMock
+  global.fetch = fetchMock as unknown as typeof fetch
   vi.clearAllMocks()
 })
 

--- a/src/pages/budget/utils/budgetStorage.test.ts
+++ b/src/pages/budget/utils/budgetStorage.test.ts
@@ -77,7 +77,7 @@ describe('saveBudgetStore', () => {
 
     // Main store should only have CSVs
     const mainStore = appStorage.getJSON<Record<string, unknown>>('budget-store', {})
-    expect(mainStore.csvs['2025-03']).toBeTruthy()
+    expect((mainStore.csvs as Record<string, unknown>)['2025-03']).toBeTruthy()
     expect(mainStore.years).toEqual([]) // years go to config
     expect(mainStore.configs).toEqual({})
 

--- a/src/pages/data/AccountsModal.test.tsx
+++ b/src/pages/data/AccountsModal.test.tsx
@@ -32,7 +32,10 @@ vi.mock('./AccountForm', () => ({
   ),
 }))
 
-const defaultProfile = makeProfile({ name: 'Alice', partner: { name: 'Bob', avatarDataUrl: '', birthday: '1991-05-20' } })
+const defaultProfile = makeProfile({
+  name: 'Alice',
+  partner: { name: 'Bob', avatarDataUrl: '', birthday: '1991-05-20' },
+})
 
 const buildAccounts = (): Account[] => [
   makeAccount({

--- a/src/pages/data/AccountsModal.test.tsx
+++ b/src/pages/data/AccountsModal.test.tsx
@@ -32,7 +32,7 @@ vi.mock('./AccountForm', () => ({
   ),
 }))
 
-const defaultProfile = makeProfile({ name: 'Alice', partner: { name: 'Bob', birthday: '1991-05-20' } })
+const defaultProfile = makeProfile({ name: 'Alice', partner: { name: 'Bob', avatarDataUrl: '', birthday: '1991-05-20' } })
 
 const buildAccounts = (): Account[] => [
   makeAccount({

--- a/src/pages/data/BalanceSpreadsheet.tsx
+++ b/src/pages/data/BalanceSpreadsheet.tsx
@@ -29,7 +29,7 @@ interface BalanceSpreadsheetProps {
   balanceMap: Map<string, number>
   profile: Profile
   inlineEntry: { month: string; values: Record<number, string>; _focused?: number } | null
-  onInlineEntryChange: (entry: { month: string; values: Record<number, string> }) => void
+  onInlineEntryChange: (entry: { month: string; values: Record<number, string>; _focused?: number }) => void
   onSaveInlineEntry: () => void
   onCancelInlineEntry: () => void
   onDeleteMonth: (month: string) => void

--- a/src/pages/data/csvExport.test.ts
+++ b/src/pages/data/csvExport.test.ts
@@ -16,9 +16,9 @@ beforeEach(() => {
   clickCalled = false
   capturedBlob = null
 
-  vi.spyOn(URL, 'createObjectURL').mockImplementation((blob: Blob) => {
+  vi.spyOn(URL, 'createObjectURL').mockImplementation((obj: Blob | MediaSource) => {
     createdUrl = 'blob:mock-url'
-    capturedBlob = blob
+    capturedBlob = obj as Blob
     return createdUrl
   })
 

--- a/src/pages/data/types.test.ts
+++ b/src/pages/data/types.test.ts
@@ -73,7 +73,12 @@ describe('formatCurrency', () => {
 
 describe('getOwnerLabels', () => {
   it('uses profile names when available', () => {
-    const profile = { name: 'Alice', avatarDataUrl: '', birthday: '1990-01-01', partner: { name: 'Bob', avatarDataUrl: '', birthday: '1991-02-02' } }
+    const profile = {
+      name: 'Alice',
+      avatarDataUrl: '',
+      birthday: '1990-01-01',
+      partner: { name: 'Bob', avatarDataUrl: '', birthday: '1991-02-02' },
+    }
     const labels = getOwnerLabels(profile)
     expect(labels.primary).toBe('Alice')
     expect(labels.partner).toBe('Bob')

--- a/src/pages/data/types.test.ts
+++ b/src/pages/data/types.test.ts
@@ -73,7 +73,7 @@ describe('formatCurrency', () => {
 
 describe('getOwnerLabels', () => {
   it('uses profile names when available', () => {
-    const profile = { name: 'Alice', birthday: '1990-01-01', partner: { name: 'Bob', birthday: '1991-02-02' } }
+    const profile = { name: 'Alice', avatarDataUrl: '', birthday: '1990-01-01', partner: { name: 'Bob', avatarDataUrl: '', birthday: '1991-02-02' } }
     const labels = getOwnerLabels(profile)
     expect(labels.primary).toBe('Alice')
     expect(labels.partner).toBe('Bob')

--- a/src/pages/drive/Drive.test.tsx
+++ b/src/pages/drive/Drive.test.tsx
@@ -417,7 +417,7 @@ describe('Drive — rename flow', () => {
   it('shows warning when target month already has data', async () => {
     const { loadBudgetStore } = await import('../budget/utils/budgetStorage')
     vi.mocked(loadBudgetStore).mockReturnValue({
-      csvs: { '2025-02': 'existing' },
+      csvs: { '2025-02': { csv: 'existing', month: '2025-02', uploadedAt: '' } },
       configs: {},
       years: [],
       categoryGroups: [],

--- a/src/pages/drive/useDriveUpload.test.ts
+++ b/src/pages/drive/useDriveUpload.test.ts
@@ -4,7 +4,7 @@ import { useDriveUpload } from './useDriveUpload'
 
 /* ─── Mock dependencies ─── */
 
-const mockUploadCSV = vi.fn(() => ({ ok: true, newCategories: [] }))
+const mockUploadCSV = vi.fn((): { ok: boolean; newCategories: string[]; error?: string } => ({ ok: true, newCategories: [] }))
 
 vi.mock('../budget/hooks/useBudget', () => ({
   useBudget: () => ({ uploadCSV: mockUploadCSV }),
@@ -137,7 +137,7 @@ describe('useDriveUpload — handlePreviewConfirm', () => {
 
   it('shows error toast when upload fails', async () => {
     vi.useFakeTimers()
-    mockUploadCSV.mockReturnValueOnce({ ok: false, error: 'Invalid format' })
+    mockUploadCSV.mockReturnValueOnce({ ok: false, newCategories: [], error: 'Invalid format' })
     setupFileReader('bad-data')
 
     const { result } = renderUploadHook()
@@ -436,12 +436,12 @@ describe('useDriveUpload — handleFileInputChange', () => {
     await act(async () => {
       const fakeFiles = [new File(['csv'], '2025-01.csv', { type: 'text/csv' })]
       const fileList = {
+        ...fakeFiles,
         length: fakeFiles.length,
         item: (i: number) => fakeFiles[i],
         [Symbol.iterator]: function* () {
           for (const f of fakeFiles) yield f
         },
-        ...fakeFiles,
       } as unknown as FileList
 
       await result.current.handleFileInputChange({

--- a/src/pages/drive/useDriveUpload.test.ts
+++ b/src/pages/drive/useDriveUpload.test.ts
@@ -4,7 +4,10 @@ import { useDriveUpload } from './useDriveUpload'
 
 /* ─── Mock dependencies ─── */
 
-const mockUploadCSV = vi.fn((): { ok: boolean; newCategories: string[]; error?: string } => ({ ok: true, newCategories: [] }))
+const mockUploadCSV = vi.fn((): { ok: boolean; newCategories: string[]; error?: string } => ({
+  ok: true,
+  newCategories: [],
+}))
 
 vi.mock('../budget/hooks/useBudget', () => ({
   useBudget: () => ({ uploadCSV: mockUploadCSV }),

--- a/src/pages/goal/components/GoalDetailedCard.tsx
+++ b/src/pages/goal/components/GoalDetailedCard.tsx
@@ -1,5 +1,5 @@
 import { FC, useState, useMemo, useCallback, useEffect, useId } from 'react'
-import { FinancialGoal } from '../types'
+import { FinancialGoal } from '../../../types'
 import GoalCardActions from './GoalCardActions'
 import { calculateGoalMetrics, projectFIDate, DEFAULT_PRE_FI_GROWTH_RATE } from '../utils/goalCalculations'
 import { parseDate as utilParseDate, getMonthsBetween } from '../utils/dateHelpers'

--- a/src/pages/goal/components/GwSection.test.tsx
+++ b/src/pages/goal/components/GwSection.test.tsx
@@ -41,7 +41,7 @@ const defaultProps = {
   onDeleteGwGoal: noop as (id: number) => void,
 }
 
-function renderGwSection(overrides: Partial<typeof defaultProps> = {}) {
+function renderGwSection(overrides: Partial<typeof defaultProps> & { initialFormOpen?: boolean } = {}) {
   return render(<GwSection {...defaultProps} {...overrides} />)
 }
 

--- a/src/pages/goal/hooks/useFinancialGoals.test.ts
+++ b/src/pages/goal/hooks/useFinancialGoals.test.ts
@@ -25,7 +25,7 @@ describe('useFinancialGoals hook', () => {
         monthlyInvestment: 5000,
         expectedReturn: 8,
         currentSavings: 100000,
-      } as FinancialGoal,
+      } as unknown as FinancialGoal,
     ]
     appStorage.setJSON('financialGoals', goals)
     const { result } = renderHook(() => useFinancialGoals())
@@ -37,15 +37,15 @@ describe('useFinancialGoals hook', () => {
 describe('useFinancialGoals cross-tab sync', () => {
   let subscribeSpy: ReturnType<typeof vi.spyOn>
   let capturedCallback: ((value: string | null) => void) | undefined
-  let unsub: ReturnType<typeof vi.fn>
+  let unsub: ReturnType<typeof vi.fn<() => void>>
 
   beforeEach(() => {
     localStorage.clear()
     capturedCallback = undefined
-    unsub = vi.fn()
+    unsub = vi.fn(() => undefined)
     subscribeSpy = vi.spyOn(appStorage, 'subscribe').mockImplementation((key, cb) => {
       if (key === 'financialGoals') capturedCallback = cb
-      return unsub
+      return () => unsub()
     })
   })
 
@@ -72,7 +72,7 @@ describe('useFinancialGoals cross-tab sync', () => {
         monthlyInvestment: 2000,
         expectedReturn: 7,
         currentSavings: 50000,
-      } as FinancialGoal,
+      } as unknown as FinancialGoal,
     ]
     appStorage.setJSON('financialGoals', updatedGoals)
 
@@ -97,7 +97,7 @@ describe('useFinancialGoals cross-tab sync', () => {
         monthlyInvestment: 1000,
         expectedReturn: 5,
         currentSavings: 5000,
-      } as FinancialGoal,
+      } as unknown as FinancialGoal,
     ]
     appStorage.setJSON('financialGoals', goals)
 
@@ -116,7 +116,7 @@ describe('useFinancialGoals cross-tab sync', () => {
         monthlyInvestment: 3000,
         expectedReturn: 6,
         currentSavings: 20000,
-      } as FinancialGoal,
+      } as unknown as FinancialGoal,
     ]
     appStorage.setJSON('financialGoals', newGoals)
 

--- a/src/pages/goal/hooks/useGwGoals.test.ts
+++ b/src/pages/goal/hooks/useGwGoals.test.ts
@@ -89,15 +89,15 @@ describe('GwGoal field migration logic', () => {
 describe('useGwGoals cross-tab sync', () => {
   let subscribeSpy: ReturnType<typeof vi.spyOn>
   let capturedCallback: ((value: string | null) => void) | undefined
-  let unsub: ReturnType<typeof vi.fn>
+  let unsub: ReturnType<typeof vi.fn<() => void>>
 
   beforeEach(() => {
     localStorage.clear()
     capturedCallback = undefined
-    unsub = vi.fn()
+    unsub = vi.fn(() => undefined)
     subscribeSpy = vi.spyOn(appStorage, 'subscribe').mockImplementation((key, cb) => {
       if (key === 'gw-goals') capturedCallback = cb
-      return unsub
+      return () => unsub()
     })
   })
 

--- a/src/pages/home/GoalsPeek.test.tsx
+++ b/src/pages/home/GoalsPeek.test.tsx
@@ -72,12 +72,12 @@ function makeAccount(id: number, goalType: 'fi' | 'gw') {
   return {
     id,
     name: `Account ${id}`,
-    type: 'retirement',
-    owner: 'primary',
+    type: 'retirement' as const,
+    owner: 'primary' as const,
     status: 'active' as const,
     goalType,
-    nature: 'asset',
-    allocation: 'us-stock',
+    nature: 'asset' as const,
+    allocation: 'us-stock' as const,
   }
 }
 

--- a/src/pages/home/Home.test.tsx
+++ b/src/pages/home/Home.test.tsx
@@ -122,7 +122,7 @@ describe('Home greeting', () => {
       visibleGoals: [],
       gwGoals: [],
       profile: { name: 'Anindya' },
-    } as ReturnType<typeof useGoals>)
+    } as unknown as ReturnType<typeof useGoals>)
     renderHome()
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Good morning, Anindya')
   })
@@ -343,7 +343,7 @@ describe('Home setup guide link', () => {
       gwGoals: [],
       profile: { name: '' },
     } as unknown as ReturnType<typeof useGoals>)
-    vi.mocked(loadBudgetStore).mockReturnValue({ csvs: { '2024': 'data' }, configs: {}, years: [], categoryGroups: [] })
+    vi.mocked(loadBudgetStore).mockReturnValue({ csvs: { '2024': { csv: 'data', month: '2024', uploadedAt: '' } }, configs: {}, years: [], categoryGroups: [] })
 
     renderHome()
 
@@ -358,7 +358,7 @@ describe('Home setup guide link', () => {
       visibleGoals: [],
       gwGoals: [],
       profile: { name: '' },
-    } as ReturnType<typeof useGoals>)
+    } as unknown as ReturnType<typeof useGoals>)
     vi.mocked(loadBudgetStore).mockReturnValue({ csvs: {}, configs: {}, years: [], categoryGroups: [] })
 
     renderHome()
@@ -498,7 +498,7 @@ describe('Home hasBudgetData flag', () => {
       visibleGoals: [],
       gwGoals: [],
       profile: { name: '' },
-    } as ReturnType<typeof useGoals>)
+    } as unknown as ReturnType<typeof useGoals>)
     renderHome()
     expect(screen.getByText('Setup guide')).toBeInTheDocument()
   })

--- a/src/pages/home/Home.test.tsx
+++ b/src/pages/home/Home.test.tsx
@@ -343,7 +343,12 @@ describe('Home setup guide link', () => {
       gwGoals: [],
       profile: { name: '' },
     } as unknown as ReturnType<typeof useGoals>)
-    vi.mocked(loadBudgetStore).mockReturnValue({ csvs: { '2024': { csv: 'data', month: '2024', uploadedAt: '' } }, configs: {}, years: [], categoryGroups: [] })
+    vi.mocked(loadBudgetStore).mockReturnValue({
+      csvs: { '2024': { csv: 'data', month: '2024', uploadedAt: '' } },
+      configs: {},
+      years: [],
+      categoryGroups: [],
+    })
 
     renderHome()
 

--- a/src/pages/settings/SettingsModal.integration.test.tsx
+++ b/src/pages/settings/SettingsModal.integration.test.tsx
@@ -40,7 +40,7 @@ import SettingsModal from './SettingsModal'
 const defaultProps = {
   darkMode: false,
   onToggleDarkMode: vi.fn(),
-  profile: { name: 'Test User', email: 'test@example.com', currency: 'USD' },
+  profile: { name: 'Test User', avatarDataUrl: '', birthday: '' },
   onUpdateProfile: vi.fn(),
   hasPendingChanges: false,
   onClose: vi.fn(),

--- a/src/pages/settings/SettingsModal.test.tsx
+++ b/src/pages/settings/SettingsModal.test.tsx
@@ -49,7 +49,7 @@ import SettingsModal from './SettingsModal'
 const defaultProps = {
   darkMode: false,
   onToggleDarkMode: vi.fn(),
-  profile: { name: 'Test User', email: 'test@example.com', currency: 'USD' },
+  profile: { name: 'Test User', avatarDataUrl: '', birthday: '' },
   onUpdateProfile: vi.fn(),
   hasPendingChanges: false,
   onClose: vi.fn(),

--- a/src/pages/settings/components/GitHubSyncPane.test.tsx
+++ b/src/pages/settings/components/GitHubSyncPane.test.tsx
@@ -680,6 +680,7 @@ describe('GitHubSyncPane', () => {
       <GitHubSyncPane
         ghConfig={{ owner: '', repo: '', filePath: 'data.json', autoSync: false }}
         ghSyncProgress={null}
+        hasPendingChanges={false}
       />,
     )
     expect(screen.getByRole('button', { name: 'Configuration' })).toBeInTheDocument()

--- a/src/pages/settings/components/GitHubSyncPane.tsx
+++ b/src/pages/settings/components/GitHubSyncPane.tsx
@@ -52,6 +52,7 @@ const GitHubSyncPane: FC<GitHubSyncPaneProps> = ({
       const timer = setTimeout(() => setGhSyncSuccess(false), 3000)
       return () => clearTimeout(timer)
     }
+    return undefined
   }, [ghSyncSuccess])
 
   const handleGhTest = async () => {

--- a/src/pages/settings/components/ProfilePane.test.tsx
+++ b/src/pages/settings/components/ProfilePane.test.tsx
@@ -123,7 +123,7 @@ describe('ProfilePane', () => {
     })
 
     it('uploads avatar via file input', async () => {
-      let capturedOnload: ((event: unknown) => void) | null = null
+      let capturedOnload = null as ((event: unknown) => void) | null
       const readAsDataURLMock = vi.fn()
 
       const OriginalFileReader = window.FileReader

--- a/src/pages/taxes/buildTaxTree.ts
+++ b/src/pages/taxes/buildTaxTree.ts
@@ -36,7 +36,7 @@ function itemFiles(item: TaxChecklistItem, accounts: Account[]): DriveFile[] {
     name: f.name,
     slug: f.id,
     ext: f.ext,
-    content: f.content,
+    content: f.content ?? '',
     uploadedAt: f.uploadedAt,
     meta: {
       owner: ownerLabel(item.owner),

--- a/src/pages/taxes/taxGitHubSync.test.ts
+++ b/src/pages/taxes/taxGitHubSync.test.ts
@@ -105,7 +105,7 @@ describe('syncAllTaxFiles', () => {
       },
     }
     const putBodies: Record<string, string>[] = []
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'PUT') {
         putBodies.push(JSON.parse(init.body as string))
         return new Response(JSON.stringify({ content: {} }), { status: 201 })

--- a/src/pages/tools/components/FICalculator.test.tsx
+++ b/src/pages/tools/components/FICalculator.test.tsx
@@ -15,7 +15,7 @@ const mockUseData = vi.fn(() => ({
 }))
 
 vi.mock('../../../contexts/DataContext', () => ({
-  useData: (...args: unknown[]) => mockUseData(...args),
+  useData: () => mockUseData(),
 }))
 
 vi.mock('../../budget/utils/budgetStorage', () => ({
@@ -148,7 +148,7 @@ describe('FICalculator', () => {
           status: 'active',
           goalType: 'fi',
           nature: 'asset',
-          allocation: 'stocks',
+          allocation: 'us-stock',
         },
       ],
       balances: [{ id: 1, accountId: 1, month: '2025-01', balance: 50_000_000 }],
@@ -184,7 +184,7 @@ describe('FICalculator', () => {
   it('increments inflation rate when plus stepper is clicked', async () => {
     const user = userEvent.setup()
     renderCalc()
-    const inflationRow = screen.getByText('Inflation').closest('.fi-calc-stepper-item')!
+    const inflationRow = screen.getByText('Inflation').closest('.fi-calc-stepper-item')! as HTMLElement
     const plusBtn = within(inflationRow)
       .getAllByRole('button')
       .find(b => b.textContent === '+')!
@@ -195,7 +195,7 @@ describe('FICalculator', () => {
   it('decrements inflation rate when minus stepper is clicked', async () => {
     const user = userEvent.setup()
     renderCalc()
-    const inflationRow = screen.getByText('Inflation').closest('.fi-calc-stepper-item')!
+    const inflationRow = screen.getByText('Inflation').closest('.fi-calc-stepper-item')! as HTMLElement
     const minusBtn = within(inflationRow)
       .getAllByRole('button')
       .find(b => b.textContent === '−')!
@@ -206,7 +206,7 @@ describe('FICalculator', () => {
   it('increments growth rate when plus stepper is clicked', async () => {
     const user = userEvent.setup()
     renderCalc()
-    const growthRow = screen.getByText('Growth').closest('.fi-calc-stepper-item')!
+    const growthRow = screen.getByText('Growth').closest('.fi-calc-stepper-item')! as HTMLElement
     const plusBtn = within(growthRow)
       .getAllByRole('button')
       .find(b => b.textContent === '+')!
@@ -217,7 +217,7 @@ describe('FICalculator', () => {
   it('decrements growth rate when minus stepper is clicked', async () => {
     const user = userEvent.setup()
     renderCalc()
-    const growthRow = screen.getByText('Growth').closest('.fi-calc-stepper-item')!
+    const growthRow = screen.getByText('Growth').closest('.fi-calc-stepper-item')! as HTMLElement
     const minusBtn = within(growthRow)
       .getAllByRole('button')
       .find(b => b.textContent === '−')!
@@ -228,7 +228,7 @@ describe('FICalculator', () => {
   it('increments retire year when plus stepper is clicked', async () => {
     const user = userEvent.setup()
     renderCalc()
-    const retireRow = screen.getByText('Retire in').closest('.fi-calc-stepper-item')!
+    const retireRow = screen.getByText('Retire in').closest('.fi-calc-stepper-item')! as HTMLElement
     const plusBtn = within(retireRow)
       .getAllByRole('button')
       .find(b => b.textContent === '+')!
@@ -240,7 +240,7 @@ describe('FICalculator', () => {
   it('decrements plan-until year when minus stepper is clicked', async () => {
     const user = userEvent.setup()
     renderCalc()
-    const planRow = screen.getByText('Plan until').closest('.fi-calc-stepper-item')!
+    const planRow = screen.getByText('Plan until').closest('.fi-calc-stepper-item')! as HTMLElement
     const minusBtn = within(planRow)
       .getAllByRole('button')
       .find(b => b.textContent === '−')!
@@ -299,7 +299,7 @@ describe('FICalculator', () => {
     expect(screen.getByText('To Delete')).toBeInTheDocument()
 
     // Delete it via the × span
-    const chip = screen.getByText('To Delete').closest('button')!
+    const chip = screen.getByText('To Delete').closest('button')! as HTMLElement
     const deleteBtn = chip.querySelector('.fi-sim-chip-x')!
     await user.click(deleteBtn)
     expect(screen.queryByText('To Delete')).not.toBeInTheDocument()
@@ -430,7 +430,7 @@ describe('FICalculator', () => {
   it('increments primary 401k year when plus stepper is clicked', async () => {
     const user = userEvent.setup()
     renderCalc()
-    const row401k = screen.getByText('Primary 401(k)').closest('.fi-calc-stepper-item')!
+    const row401k = screen.getByText('Primary 401(k)').closest('.fi-calc-stepper-item')! as HTMLElement
     const initial = row401k.querySelector('.fi-calc-step-val')!.textContent!
     const plusBtn = within(row401k)
       .getAllByRole('button')
@@ -484,7 +484,7 @@ describe('FICalculator', () => {
           status: 'active',
           goalType: 'fi',
           nature: 'asset',
-          allocation: { usEquity: 100, intlEquity: 0, usBond: 0, intlBond: 0, cash: 0, other: 0 },
+          allocation: 'us-stock',
         },
       ],
       balances: [{ id: 1, accountId: 1, month: '2025-01', balance: 100000 }],
@@ -513,7 +513,7 @@ describe('FICalculator', () => {
           status: 'active',
           goalType: 'fi',
           nature: 'asset',
-          allocation: { usEquity: 100, intlEquity: 0, usBond: 0, intlBond: 0, cash: 0, other: 0 },
+          allocation: 'us-stock',
         },
       ],
       balances: [{ id: 2, accountId: 2, month: '2025-01', balance: 80000 }],
@@ -612,10 +612,10 @@ describe('FICalculator', () => {
     const { parseCSV } = await import('../../budget/utils/csvParser')
 
     const lastYear = new Date().getFullYear() - 1
-    const csvs: Record<string, { csv: string }> = {}
+    const csvs: Record<string, { csv: string; month: string; uploadedAt: string }> = {}
     for (let m = 1; m <= 12; m++) {
       const key = `${lastYear}-${String(m).padStart(2, '0')}`
-      csvs[key] = { csv: 'test' }
+      csvs[key] = { csv: 'test', month: key, uploadedAt: '' }
     }
 
     vi.mocked(loadBudgetStore).mockReturnValue({
@@ -645,7 +645,7 @@ describe('FICalculator', () => {
 
     const user = userEvent.setup()
     renderCalc()
-    const row = screen.getByText('Partner 401(k)').closest('.fi-calc-stepper-item')!
+    const row = screen.getByText('Partner 401(k)').closest('.fi-calc-stepper-item')! as HTMLElement
     const initial = row.querySelector('.fi-calc-step-val')!.textContent!
     const plusBtn = within(row)
       .getAllByRole('button')

--- a/src/pages/tools/components/SavingsGrowthTracker.test.tsx
+++ b/src/pages/tools/components/SavingsGrowthTracker.test.tsx
@@ -17,7 +17,7 @@ const mockUseData = vi.fn(() => ({
 }))
 
 vi.mock('../../../contexts/DataContext', () => ({
-  useData: (...args: unknown[]) => mockUseData(...args),
+  useData: () => mockUseData(),
 }))
 
 vi.mock('../../budget/utils/budgetStorage', () => ({
@@ -70,7 +70,7 @@ describe('SavingsGrowthTracker', () => {
           status: 'active',
           goalType: 'fi',
           nature: 'asset',
-          allocation: 'stocks',
+          allocation: 'us-stock',
         },
       ],
       balances: [{ id: 1, accountId: 1, month: '2023-12', balance: 100000 }],
@@ -100,7 +100,7 @@ describe('SavingsGrowthTracker', () => {
           status: 'active',
           goalType: 'fi',
           nature: 'asset',
-          allocation: 'stocks',
+          allocation: 'us-stock',
         },
       ],
       balances: [{ id: 1, accountId: 1, month: '2023-12', balance: 100000 }],

--- a/src/search/searchIndex.test.ts
+++ b/src/search/searchIndex.test.ts
@@ -336,7 +336,17 @@ describe('search', () => {
     const categories = groups.map(g => g.category)
 
     // Verify order matches CATEGORY_ORDER: page, command, goal, account, ...tool, settings
-    const ORDER: SearchCategory[] = ['page', 'command', 'goal', 'account', 'budget', 'tax', 'allocation', 'tool', 'settings']
+    const ORDER: SearchCategory[] = [
+      'page',
+      'command',
+      'goal',
+      'account',
+      'budget',
+      'tax',
+      'allocation',
+      'tool',
+      'settings',
+    ]
     const filtered = ORDER.filter(c => categories.includes(c))
     expect(categories).toEqual(filtered)
   })

--- a/src/search/searchIndex.test.ts
+++ b/src/search/searchIndex.test.ts
@@ -1,6 +1,6 @@
 import { buildIndex, search, findMatchRange, getCategoryLabel } from './searchIndex'
 import { appStorage } from '../utils/appStorage'
-import type { SearchItem } from './searchIndex'
+import type { SearchItem, SearchCategory } from './searchIndex'
 
 beforeEach(() => {
   localStorage.clear()
@@ -336,7 +336,7 @@ describe('search', () => {
     const categories = groups.map(g => g.category)
 
     // Verify order matches CATEGORY_ORDER: page, command, goal, account, ...tool, settings
-    const ORDER = ['page', 'command', 'goal', 'account', 'budget', 'tax', 'allocation', 'tool', 'settings']
+    const ORDER: SearchCategory[] = ['page', 'command', 'goal', 'account', 'budget', 'tax', 'allocation', 'tool', 'settings']
     const filtered = ORDER.filter(c => categories.includes(c))
     expect(categories).toEqual(filtered)
   })

--- a/src/utils/appStorage.integration.test.ts
+++ b/src/utils/appStorage.integration.test.ts
@@ -64,7 +64,7 @@ describe('appStorage integration', () => {
     })
 
     // 5. Flush persists
-    await new Promise(resolve => queueMicrotask(resolve))
+    await new Promise<void>(resolve => queueMicrotask(() => resolve()))
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // Verify encrypted envelope was written to localStorage
@@ -190,7 +190,7 @@ describe('appStorage integration', () => {
     appStorage.setJSON('budget-store', { csvs: {} })
 
     // Flush
-    await new Promise(resolve => queueMicrotask(resolve))
+    await new Promise<void>(resolve => queueMicrotask(() => resolve()))
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // Each key should have been encrypted once

--- a/src/utils/appStorage.test.ts
+++ b/src/utils/appStorage.test.ts
@@ -168,7 +168,7 @@ describe('appStorage', () => {
     appStorage.setJSON('user-profile', { name: 'Secret' })
 
     // Flush the microtask queue
-    await new Promise(resolve => queueMicrotask(resolve))
+    await new Promise<void>(resolve => queueMicrotask(() => resolve()))
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(crypto.encryptString).toHaveBeenCalledWith(JSON.stringify({ name: 'Secret' }), mockCryptoKey)
@@ -191,7 +191,7 @@ describe('appStorage', () => {
     appStorage.setJSON('user-profile', { name: 'C' })
 
     // Flush microtask
-    await new Promise(resolve => queueMicrotask(resolve))
+    await new Promise<void>(resolve => queueMicrotask(() => resolve()))
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // encryptString should only be called once (last value wins)
@@ -334,14 +334,14 @@ describe('appStorage', () => {
     await appStorage.hydrate(mockCryptoKey)
 
     appStorage.setString('user-profile', 'value-to-remove')
-    await new Promise(resolve => queueMicrotask(resolve))
+    await new Promise<void>(resolve => queueMicrotask(() => resolve()))
     await new Promise(resolve => setTimeout(resolve, 0))
 
     appStorage.remove('user-profile')
     expect(appStorage.getString('user-profile')).toBeNull()
 
     // Flush the microtask
-    await new Promise(resolve => queueMicrotask(resolve))
+    await new Promise<void>(resolve => queueMicrotask(() => resolve()))
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(localStorage.getItem('user-profile')).toBeNull()

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -30,12 +30,12 @@ export const bytesToB64 = (bytes: Uint8Array): string => {
   return btoa(binary)
 }
 
-export const b64ToBytes = (b64: string): Uint8Array => Uint8Array.from(atob(b64), c => c.charCodeAt(0))
+export const b64ToBytes = (b64: string): Uint8Array<ArrayBuffer> => Uint8Array.from(atob(b64), c => c.charCodeAt(0))
 
 // ── Key derivation ─────────────────────────────────────────────
 
 /** Derive an AES-256-GCM CryptoKey from a passphrase + salt (PBKDF2, 310 000 iterations, SHA-256). */
-export async function deriveKey(passphrase: string, salt: Uint8Array): Promise<CryptoKey> {
+export async function deriveKey(passphrase: string, salt: Uint8Array<ArrayBuffer>): Promise<CryptoKey> {
   const baseKey = await crypto.subtle.importKey('raw', new TextEncoder().encode(passphrase), 'PBKDF2', false, [
     'deriveKey',
   ])

--- a/src/utils/importValidator.ts
+++ b/src/utils/importValidator.ts
@@ -86,7 +86,7 @@ function validateGoal(g: unknown, index: number, warnings: string[]): FinancialG
     warnings.push(`goals[${index}]: missing or empty "goalName" — skipped`)
     return null
   }
-  return g as FinancialGoal
+  return g as unknown as FinancialGoal
 }
 
 function validateGwGoal(g: unknown, index: number, warnings: string[]): GwGoal | null {
@@ -106,7 +106,7 @@ function validateGwGoal(g: unknown, index: number, warnings: string[]): GwGoal |
     warnings.push(`gwGoals[${index}]: missing or empty "label" — skipped`)
     return null
   }
-  return g as GwGoal
+  return g as unknown as GwGoal
 }
 
 function validateAccount(a: unknown, index: number, warnings: string[]): Account | null {
@@ -122,7 +122,7 @@ function validateAccount(a: unknown, index: number, warnings: string[]): Account
     warnings.push(`dataAccounts[${index}]: missing or empty "name" — skipped`)
     return null
   }
-  return a as Account
+  return a as unknown as Account
 }
 
 function validateBalance(b: unknown, index: number, warnings: string[]): BalanceEntry | null {
@@ -146,7 +146,7 @@ function validateBalance(b: unknown, index: number, warnings: string[]): Balance
     warnings.push(`dataBalances[${index}]: missing or invalid "balance" — skipped`)
     return null
   }
-  return b as BalanceEntry
+  return b as unknown as BalanceEntry
 }
 
 function sanitizeProfile(raw: unknown, warnings: string[]): Partial<Profile> | undefined {
@@ -258,7 +258,7 @@ function validateTaxTemplate(t: unknown, index: number, warnings: string[]): Tax
     warnings.push(`taxTemplates[${index}]: missing or invalid "items" array — skipped`)
     return null
   }
-  return t as TaxTemplate
+  return t as unknown as TaxTemplate
 }
 
 // ── Main validator ─────────────────────────────────────────────

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["vitest/globals", "node"],
     "module": "ESNext",
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vitest/globals", "node"],
     "module": "ESNext",
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Adds `tsc --noEmit` as a first-class quality gate to prevent TypeScript regressions.

## Phases
- **Phase A** (`869add1`): Added `vitest/globals` and `node` types to `tsconfig.json`; lib bumped to ES2022 for `Array.prototype.at()`.
- **Phase B** (`a7a5766`): Fixed TypeScript errors in production code — crypto buffer types, missing imports, return-type narrowing, Recharts formatter casts, etc.
- **Phase C** (`ad0d801`): Fixed TypeScript errors in test files — Profile shape, AssetAllocation string union, MonthCSV shape, RestoreResult, FlagContextValue mocks, subscribe mocks, etc.
- **Phase D** (this commit): Wired typecheck into the developer workflow.
  - `npm run typecheck` script
  - `.husky/pre-push` step
  - CI `build` job step (before vitest; deploy block untouched)
  - `CONTRIBUTING.md` updates

## Verification
- `npm run typecheck` → 0 errors
- `npx vitest run` → 132 files, 2693 tests passing
- No behavior changes; all fixes are type-only

Fixes #185

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>