### PR TITLE
fix: bundle cleanup of #172, #173, #174, #176, #138

### DIFF
--- a/e2e/cross-page-home.spec.ts
+++ b/e2e/cross-page-home.spec.ts
@@ -1,11 +1,6 @@
 import { test, expect, Page } from '@playwright/test'
-import {
-  buildV2Export,
-  CROSS_PAGE_GOAL,
-  mutateAccountBalance,
-  seedCrossPage,
-  URLS,
-} from './fixtures/cross-page-data'
+import { buildV2Export, CROSS_PAGE_GOAL, mutateAccountBalance, seedCrossPage, URLS } from './fixtures/cross-page-data'
+import { waitForReload } from './fixtures/reload'
 
 /**
  * Sub-issue #151 (62a of 4 under #62) — Home dashboard cross-page
@@ -470,37 +465,22 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       // counter could have been bumped by any prior remount dispatch).
       await page.evaluate(() => localStorage.setItem('__test_data_changed_count', '0'))
 
-      // C6 (navigation-resilient gate): plant a sentinel on `window`
-      // BEFORE the trigger. ImportExportContext schedules
-      // window.location.reload() at +200ms (ImportExportContext.tsx:128),
-      // which destroys this window and creates a fresh one without the
-      // sentinel. page.waitForFunction is navigation-resilient: it
-      // re-evaluates the predicate in the new execution context after
-      // navigation and resolves only when the sentinel is absent.
-      //
-      // Why not waitForLoadState('load')? It returns immediately when
-      // the page is already in 'load' state (Playwright semantics) and
-      // does not wait for any FUTURE navigation, so it provides no
-      // protection against the +200ms reload — the subsequent
-      // page.evaluate then races the navigation and throws
-      // "Execution context was destroyed".
-      await page.evaluate(() => {
-        ;(window as unknown as { __preReloadSentinel?: boolean }).__preReloadSentinel = true
-      })
-
+      // Navigation-resilient gate for the post-import reload
+      // (ImportExportContext.handleImport calls window.location.reload()
+      // after dispatching `data-changed`). `waitForLoadState('load')`
+      // is unusable — it resolves immediately when the page is already
+      // loaded and does not wait for any FUTURE navigation, so the next
+      // page.evaluate races the reload and throws "Execution context
+      // was destroyed". See e2e/fixtures/reload.ts for the sentinel
+      // pattern (extracted in #172).
       const v2 = buildV2Export()
-      await page.locator('input[type="file"][accept=".json"]').setInputFiles({
-        name: v2.name,
-        mimeType: 'application/json',
-        buffer: Buffer.from(v2.content),
+      await waitForReload(page, async () => {
+        await page.locator('input[type="file"][accept=".json"]').setInputFiles({
+          name: v2.name,
+          mimeType: 'application/json',
+          buffer: Buffer.from(v2.content),
+        })
       })
-
-      // Wait for the reload to actually happen: sentinel will be missing
-      // in the new window object. waitForFunction handles the mid-flight
-      // execution-context destruction by retrying in the new context.
-      await page.waitForFunction(
-        () => !(window as unknown as { __preReloadSentinel?: boolean }).__preReloadSentinel,
-      )
       await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible()
 
       const accounts = await page.evaluate(() => localStorage.getItem('data-accounts'))
@@ -511,9 +491,7 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       // Reload does NOT re-dispatch on mount (verified: no remount-
       // dispatch in DataContext). Cap at 5 to catch runaway dispatches
       // if a future refactor adds remount-on-mount behavior.
-      const count = await page.evaluate(() =>
-        Number(localStorage.getItem('__test_data_changed_count') || '0'),
-      )
+      const count = await page.evaluate(() => Number(localStorage.getItem('__test_data_changed_count') || '0'))
       expect(count).toBeGreaterThanOrEqual(1)
       expect(count).toBeLessThanOrEqual(5)
 
@@ -523,9 +501,7 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
       await expect(page.locator('.home-card--nw .nw-amount')).toContainText('$315,000')
     })
 
-    test('41. Allocation ratio update fires allocation-changed and Home stays consistent', async ({
-      page,
-    }) => {
+    test('41. Allocation ratio update fires allocation-changed and Home stays consistent', async ({ page }) => {
       // ADAPTATION (F): the Home AllocationBreakdown card consumes
       // accounts + balances from DataContext — it does NOT read
       // `allocation-custom-ratios`. So a ratios mutation will NOT
@@ -572,20 +548,16 @@ test.describe('Cross-page: Home Dashboard Integration (#151)', () => {
 
       // Await the counter increment (C4 poll pattern).
       await expect
-        .poll(
-          () =>
-            page.evaluate(() => Number(localStorage.getItem('__test_alloc_changed_count') || '0')),
-          { timeout: 5000 },
-        )
+        .poll(() => page.evaluate(() => Number(localStorage.getItem('__test_alloc_changed_count') || '0')), {
+          timeout: 5000,
+        })
         .toBeGreaterThanOrEqual(1)
 
       // M6: we dispatch the event exactly once above, and saveCustomRatios
       // (allocation/utils.ts:13) is the only production dispatcher and also
       // fires once per save. No remount-dispatch occurs. We assert the
       // strict exact-count contract.
-      const count = await page.evaluate(() =>
-        Number(localStorage.getItem('__test_alloc_changed_count') || '0'),
-      )
+      const count = await page.evaluate(() => Number(localStorage.getItem('__test_alloc_changed_count') || '0'))
       expect(count).toBe(1)
 
       // Home re-renders cleanly after navigating away and back.

--- a/e2e/fixtures/reload.ts
+++ b/e2e/fixtures/reload.ts
@@ -1,0 +1,37 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Navigation-resilient wait for a `window.location.reload()` triggered by an
+ * in-page action (e.g. ImportExportContext.handleImport, factory reset).
+ *
+ * Why this exists: `page.waitForLoadState('load')` is unusable as a post-
+ * reload gate — Playwright resolves it immediately when the page is already
+ * in the `load` state and does NOT wait for any FUTURE navigation. That
+ * lets the next `page.evaluate(...)` race the reload and throw
+ * "Execution context was destroyed".
+ *
+ * The fix is a window-sentinel: plant a flag on `window` BEFORE the trigger
+ * runs, then `page.waitForFunction` for its absence. `waitForFunction` is
+ * navigation-resilient — it re-evaluates the predicate in the new execution
+ * context after the reload and resolves only when the sentinel is missing.
+ *
+ * Originally inlined in cross-page-home.spec.ts test 39 (PR #171); extracted
+ * here per #172 so settings.spec.ts and any other suite needing a post-reload
+ * gate can use the same primitive.
+ *
+ * Usage:
+ * ```ts
+ * await waitForReload(page, async () => {
+ *   await someFileInput.setInputFiles({ ... })
+ * })
+ * // Reload has fully settled; safe to evaluate, navigate, or assert.
+ * ```
+ */
+export async function waitForReload(page: Page, trigger: () => Promise<void>): Promise<void> {
+  const SENTINEL = '__preReloadSentinel'
+  await page.evaluate(key => {
+    ;(window as unknown as Record<string, boolean>)[key] = true
+  }, SENTINEL)
+  await trigger()
+  await page.waitForFunction(key => !(window as unknown as Record<string, boolean>)[key], SENTINEL)
+}

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -213,9 +213,7 @@ test.describe('Home Dashboard E2E', () => {
       const home = new HomePage(page)
       await home.goto()
 
-      await expect(home.nwCard).toContainText(
-        'Add accounts and record your first balance to see your net worth here.',
-      )
+      await expect(home.nwCard).toContainText('Add accounts and record your first balance to see your net worth here.')
       await expect(home.getNwCardCtaBtn()).toHaveText('Add your data →')
     })
 
@@ -253,9 +251,7 @@ test.describe('Home Dashboard E2E', () => {
       await expect(home.reorderAnnouncement).toHaveText('Net Worth moved to position 2')
 
       // M2 Test 14: Assert localStorage matches expected order
-      const storedOrder = await page.evaluate(() =>
-        JSON.parse(localStorage.getItem('home-card-order') || '[]'),
-      )
+      const storedOrder = await page.evaluate(() => JSON.parse(localStorage.getItem('home-card-order') || '[]'))
       expect(storedOrder).toEqual([1, 0, 2, 3])
 
       await context.close()
@@ -280,9 +276,7 @@ test.describe('Home Dashboard E2E', () => {
 
       // Reload — addInitScript will re-seed but home-card-order should persist
       // So instead, seed the card order AFTER the move and before reload via evaluate
-      const savedOrder = await page.evaluate(() =>
-        localStorage.getItem('home-card-order'),
-      )
+      const savedOrder = await page.evaluate(() => localStorage.getItem('home-card-order'))
 
       // Reload page. addInitScript will re-clear localStorage, so we need to
       // re-inject the card order after reload via a second addInitScript
@@ -358,9 +352,7 @@ test.describe('Home Dashboard E2E', () => {
   })
 
   test.describe('Edge Cases', () => {
-    test('handles corrupted home-card-order gracefully by falling back to default', async ({
-      page,
-    }) => {
+    test('handles corrupted home-card-order gracefully by falling back to default', async ({ page }) => {
       await page.addInitScript(() => {
         localStorage.clear()
         localStorage.setItem('encryption-enabled', '0')
@@ -398,9 +390,7 @@ test.describe('Home Dashboard E2E', () => {
   })
 
   test.describe('Data Corruption & Resilience', () => {
-    test('app renders home page when localStorage has malformed data-accounts', async ({
-      page,
-    }) => {
+    test('app renders home page when localStorage has malformed data-accounts', async ({ page }) => {
       // C5 Test 21: Corrupted data-accounts triggers error boundary or graceful fallback
       await page.addInitScript(() => {
         localStorage.clear()
@@ -497,17 +487,35 @@ test.describe('Home Dashboard E2E', () => {
       const options = home.searchResults.locator('[role="option"]')
       await expect(options.first()).toBeVisible()
 
-      // Verify active item exists
-      await expect(home.searchResultActive).toBeVisible()
+      // Stabilize the active item before capturing the baseline id.
+      // The search result reducer can briefly point to the first option
+      // before settling on the scored/recent preference; capturing
+      // firstId during that transient gave us flake #138. Poll until
+      // two consecutive reads return the same id.
+      let prevId: string | null = null
+      await expect
+        .poll(
+          async () => {
+            const id = await home.searchResultActive.getAttribute('id')
+            const stable = id !== null && id === prevId
+            prevId = id
+            return stable
+          },
+          { intervals: [50, 50, 100, 100, 200] },
+        )
+        .toBe(true)
       const firstId = await home.searchResultActive.getAttribute('id')
 
-      // Arrow down moves selection
+      // Arrow down moves selection. The keydown handler is attached on
+      // the modal root and may not be live on the very first paint, so
+      // poll the active id for change instead of doing a single read
+      // race (#138 root cause #2).
       await page.keyboard.press('ArrowDown')
-
-      // Active item should have changed
-      await expect(home.searchResultActive).toBeVisible()
-      const newId = await home.searchResultActive.getAttribute('id')
-      expect(newId).not.toBe(firstId)
+      await expect
+        .poll(() => home.searchResultActive.getAttribute('id'), {
+          intervals: [50, 50, 100, 100, 200],
+        })
+        .not.toBe(firstId)
     })
 
     test('Tab through dashboard cards reaches interactive elements', async ({ page }) => {
@@ -535,11 +543,7 @@ test.describe('Home Dashboard E2E', () => {
           const el = document.activeElement
           if (!el) return false
           const style = window.getComputedStyle(el)
-          return (
-            style.outlineStyle !== 'none' ||
-            style.boxShadow !== 'none' ||
-            el.matches(':focus-visible')
-          )
+          return style.outlineStyle !== 'none' || style.boxShadow !== 'none' || el.matches(':focus-visible')
         })
         expect(hasFocusStyle).toBe(true)
       }
@@ -622,8 +626,6 @@ test.describe('Home Dashboard E2E', () => {
       const cardH2s = home.cardGrid.locator('h2')
       await expect(cardH2s).toHaveCount(0)
     })
-
-
   })
 
   test.describe('Error Recovery', () => {

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -11,6 +11,7 @@ import {
   seedProfile,
   V2_EXPORT_KEYS,
 } from './fixtures/settings.fixtures'
+import { waitForReload } from './fixtures/reload'
 
 test.describe('Settings — Non-Security E2E', () => {
   /* ── Settings — Profile ───────────────────────────────────────── */
@@ -358,22 +359,23 @@ test.describe('Settings — Non-Security E2E', () => {
       await settings.navTo('advanced')
 
       const v1 = buildV1Import()
-      // Note: ImportExportContext.handleImport schedules window.location.reload()
-      // 200ms after the FileReader resolves. We don't race with that — we
-      // poll for the imported value to surface in localStorage and let the
-      // reload happen in the background.
-      await settings.importFileInput.setInputFiles({
-        name: v1.name,
-        mimeType: 'application/json',
-        buffer: Buffer.from(v1.content),
+      // ImportExportContext.handleImport calls window.location.reload()
+      // after dispatching `data-changed`. waitForLoadState('load') is
+      // unusable here (resolves immediately when the page is already
+      // loaded; does not wait for any FUTURE navigation), letting the
+      // next page.evaluate race the reload. Use the sentinel helper
+      // extracted in #172 to gate on the actual reload landing.
+      await waitForReload(page, async () => {
+        await settings.importFileInput.setInputFiles({
+          name: v1.name,
+          mimeType: 'application/json',
+          buffer: Buffer.from(v1.content),
+        })
       })
 
       // Goal is in localStorage under financialGoals (survives reload).
-      await expect
-        .poll(() => page.evaluate(() => localStorage.getItem('financialGoals')), { timeout: 10_000 })
-        .toContain('FI Goal')
-      // Ensure the post-import reload has settled before we navigate.
-      await page.waitForLoadState('domcontentloaded')
+      const stored = await page.evaluate(() => localStorage.getItem('financialGoals'))
+      expect(stored).toContain('FI Goal')
 
       // Goals page renders the imported goal — guards against a regression
       // where the validator accepts the payload but the Goals page filters
@@ -406,17 +408,20 @@ test.describe('Settings — Non-Security E2E', () => {
       await settings.navTo('advanced')
 
       const v2 = buildV2ImportWithUnknown()
-      await settings.importFileInput.setInputFiles({
-        name: v2.name,
-        mimeType: 'application/json',
-        buffer: Buffer.from(v2.content),
+      // Sentinel-gated reload (see #172): waitForLoadState('load') is a
+      // no-op when the page is already loaded and does not wait for the
+      // FUTURE reload that handleImport triggers.
+      await waitForReload(page, async () => {
+        await settings.importFileInput.setInputFiles({
+          name: v2.name,
+          mimeType: 'application/json',
+          buffer: Buffer.from(v2.content),
+        })
       })
 
       // Known goal made it through.
-      await expect
-        .poll(() => page.evaluate(() => localStorage.getItem('financialGoals')), { timeout: 10_000 })
-        .toContain('V2 Imported Goal')
-      await page.waitForLoadState('domcontentloaded')
+      const stored = await page.evaluate(() => localStorage.getItem('financialGoals'))
+      expect(stored).toContain('V2 Imported Goal')
 
       // Anti-leak: neither unknown key name appears as a localStorage key.
       const keys = await page.evaluate(() => Object.keys(localStorage))
@@ -570,21 +575,13 @@ test.describe('Settings — Non-Security E2E', () => {
 
       // No horizontal scrollbar on <html> while modal is open.
       await expect
-        .poll(() =>
-          page.evaluate(
-            () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
-          ),
-        )
+        .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth))
         .toBe(true)
 
       // Close the modal and check Home greeting also doesn't overflow.
       await settings.closeButton.click()
       await expect
-        .poll(() =>
-          page.evaluate(
-            () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
-          ),
-        )
+        .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth))
         .toBe(true)
     })
 
@@ -598,10 +595,7 @@ test.describe('Settings — Non-Security E2E', () => {
       await settings.open()
       await settings.navTo('advanced')
 
-      const [download] = await Promise.all([
-        page.waitForEvent('download'),
-        settings.exportBtn.click(),
-      ])
+      const [download] = await Promise.all([page.waitForEvent('download'), settings.exportBtn.click()])
 
       // Read the streamed file body into a string and JSON.parse it.
       const stream = await download.createReadStream()
@@ -618,14 +612,8 @@ test.describe('Settings — Non-Security E2E', () => {
       // Per-key presence + non-null assertion (each gets its own failure message).
       for (const key of V2_EXPORT_KEYS) {
         expect(exported, `v2 export must contain top-level key "${key}"`).toHaveProperty(key)
-        expect(
-          exported[key],
-          `v2 export key "${key}" must not be null`,
-        ).not.toBeNull()
-        expect(
-          exported[key],
-          `v2 export key "${key}" must not be undefined`,
-        ).not.toBeUndefined()
+        expect(exported[key], `v2 export key "${key}" must not be null`).not.toBeNull()
+        expect(exported[key], `v2 export key "${key}" must not be undefined`).not.toBeUndefined()
       }
 
       // Spot-check seeded values flowed through (catches accidental

--- a/src/pages/taxes/useTaxStore.test.tsx
+++ b/src/pages/taxes/useTaxStore.test.tsx
@@ -37,6 +37,45 @@ describe('useTaxStore', () => {
       expect(result.current.allYears).toEqual([2024])
       expect(result.current.getYear(2024).items).toHaveLength(1)
     })
+
+    it('normalizes empty object to EMPTY_STORE without crashing the mount effect', () => {
+      // Regression #176: `appStorage.getJSON` only returns the fallback
+      // when the key is ABSENT, so a stored `{}` flowed through and
+      // crashed the mount effect at `Object.values(initial.years).some
+      // (...)`. Reachable via prior `buildV2Export` revisions that wrote
+      // `taxStore: {}` and via importValidator accepting any object.
+      localStorage.setItem('tax-store', '{}')
+      const { result } = renderHook(() => useTaxStore(), { wrapper })
+      expect(result.current.allYears).toEqual([])
+      expect(result.current.store.years).toEqual({})
+    })
+
+    it('normalizes missing years field to EMPTY_STORE', () => {
+      localStorage.setItem('tax-store', JSON.stringify({ somethingElse: true }))
+      const { result } = renderHook(() => useTaxStore(), { wrapper })
+      expect(result.current.store.years).toEqual({})
+    })
+
+    it('normalizes non-object years field to EMPTY_STORE', () => {
+      localStorage.setItem('tax-store', JSON.stringify({ years: 'oops' }))
+      const { result } = renderHook(() => useTaxStore(), { wrapper })
+      expect(result.current.store.years).toEqual({})
+    })
+
+    it('normalizes array years field to EMPTY_STORE (typeof [] === object)', () => {
+      // Arrays pass `typeof === 'object'`. Without an explicit
+      // Array.isArray guard, `{years: []}` would slip past load() and
+      // let numeric array indices masquerade as year keys.
+      localStorage.setItem('tax-store', JSON.stringify({ years: [] }))
+      const { result } = renderHook(() => useTaxStore(), { wrapper })
+      expect(result.current.store.years).toEqual({})
+    })
+
+    it('normalizes top-level array to EMPTY_STORE', () => {
+      localStorage.setItem('tax-store', JSON.stringify([]))
+      const { result } = renderHook(() => useTaxStore(), { wrapper })
+      expect(result.current.store.years).toEqual({})
+    })
   })
 
   describe('getYear', () => {

--- a/src/pages/taxes/useTaxStore.ts
+++ b/src/pages/taxes/useTaxStore.ts
@@ -17,7 +17,26 @@ import { appStorage } from '../../utils/appStorage'
 const STORAGE_KEY = 'tax-store'
 
 function load(): TaxStore {
-  return appStorage.getJSON<TaxStore>(STORAGE_KEY, EMPTY_STORE)
+  // Guard against malformed shapes. `appStorage.getJSON` only returns
+  // the fallback when the key is ABSENT, so a stored `{}` (or any
+  // object missing `years`) flows through and crashes the mount
+  // effect at `Object.values(initial.years).some(...)` below. Reachable
+  // from real users via prior `buildV2Export()` revisions that wrote
+  // `taxStore: {}` and via hand-edited / partial-migration storage —
+  // `importValidator` only checks `isRecord(parsed.taxStore)` and
+  // accepts any object. Normalize here so consumers always see a
+  // well-formed store. Arrays are explicitly rejected: `typeof [] ===
+  // 'object'`, so `{years: []}` would otherwise pass and let numeric
+  // array indices masquerade as year keys downstream. (#176)
+  const s = appStorage.getJSON<TaxStore>(STORAGE_KEY, EMPTY_STORE)
+  return s &&
+    typeof s === 'object' &&
+    !Array.isArray(s) &&
+    s.years &&
+    typeof s.years === 'object' &&
+    !Array.isArray(s.years)
+    ? s
+    : EMPTY_STORE
 }
 
 function save(store: TaxStore) {


### PR DESCRIPTION
Bundles cleanup of 5 issues into one PR with 5 clean commits.

## Commits

1. **`0e8d166` test(e2e): extract waitForReload helper** — Fixes #172
   New `e2e/fixtures/reload.ts` with `waitForReload(page, trigger)` (window-sentinel + `waitForFunction`). Migrates `cross-page-home.spec.ts` test 39.

2. **`c6b3d65` test(e2e): gate settings.spec.ts tests 14/15 on waitForReload** — Fixes #173
   Replaces racy `waitForLoadState('domcontentloaded')` and `expect.poll` localStorage reads with the helper + synchronous assertions.

3. **`be59b5f` refactor(import): replace 200ms setTimeout reload with queueMicrotask** — Fixes #174
   Drops the magic 200ms delay in `ImportExportContext.tsx`. Two unit tests rewritten to flush via `await Promise.resolve()` instead of fake timers. Stale `200ms` comments swept across e2e suite and docs.

4. **`da86ffb` fix(taxes): normalize malformed tax-store shape** — Fixes #176
   Hardens `useTaxStore.load()` against `{}`, `{years: 'oops'}`, `{years: []}`, top-level `[]`, etc. `appStorage.getJSON` only falls back on absent keys, not malformed values. Includes `!Array.isArray` guard (caught in Emery review). 5 new tests.

5. **`ef07aef` test(e2e): stabilize home search arrow-key navigation** — Fixes #138
   Pre-existing flake on main (`e2e/home.spec.ts:484`). Two races: reducer briefly picks first option before settling, and modal keydown listener not attached on first paint. Both fixed with `expect.poll` (stabilize firstId before ArrowDown; poll post-ArrowDown read). 10/10 local repeats pass with `--repeat-each=10 --workers=1`. Bundled here at user request to unblock main CI.

## Validation

- `npx tsc --noEmit` clean
- `npx vitest run` green: 132 files, 2696 tests
- E2E #138 verified stable over 10 consecutive repeats
- Emery code review completed pre-push; array-guard + stale comment fixes applied

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
