### PR TITLE
Batch cleanup: #130 #135 #155 #160 #161

### DIFF
--- a/e2e/drive.spec.ts
+++ b/e2e/drive.spec.ts
@@ -148,31 +148,19 @@ test.describe('Drive — File Manager E2E', () => {
 
   test.describe('Empty state', () => {
     test('7. Drive shows no files and no year folders when nothing has been uploaded', async ({ page }) => {
-      // ADAPTATION: buildBudgetTree always pushes a top-level "Budget"
-      // folder, so the .drive-empty message in Drive.tsx is unreachable
-      // under realistic data. The empty state the user actually sees is:
-      // a single "Budget" folder at /drive with "0 items", and zero file
-      // rows anywhere in the tree. Filed follow-up to revisit the dead
-      // .drive-empty branch (see report).
+      // Issue #135: buildDriveTree now omits the empty Budget folder, so
+      // the .drive-empty message becomes reachable. At root the user sees
+      // no folders, no files, and the empty-state message.
       await seedDriveEmpty(page)
       const drive = new DrivePage(page)
       await drive.goto()
 
-      // Root shows only the empty Budget folder, with explicit "0 items" meta.
-      await expect(drive.folder('Budget')).toBeVisible()
-      await expect(drive.folder('Budget').locator('.drive-row-meta')).toHaveText('0 items')
-      // Zero CSV files anywhere on the page.
-      await expect(page.locator('.drive-row--file')).toHaveCount(0)
-
-      // Drilling into the empty Budget folder shows no folders, no files,
-      // just the .. back row and the drop zone prompt.
-      await drive.folder('Budget').click()
-      await expect(page).toHaveURL(/#\/drive\/budget$/)
-      await expect(drive.backRow).toBeVisible()
+      // Root shows zero folders and zero files.
       await expect(page.locator('.drive-row--folder')).toHaveCount(0)
       await expect(page.locator('.drive-row--file')).toHaveCount(0)
-      await expect(drive.dropZone).toBeVisible()
-      await expect(drive.dropZone).toContainText(/Drag & drop CSV files/)
+      // The empty-state message is visible.
+      await expect(page.locator('.drive-empty')).toBeVisible()
+      await expect(page.locator('.drive-empty')).toContainText(/No budget files yet/i)
     })
   })
 

--- a/e2e/keyboard-nav.spec.ts
+++ b/e2e/keyboard-nav.spec.ts
@@ -204,12 +204,10 @@ test.describe('Keyboard navigation, focus, ErrorBoundary, perf (#144)', () => {
 
   /* ── 34. Skip to main content link (DOCUMENTS GAP) ────────── */
 
-  test('34. Skip to main content link (if present) works on Tab from page load', async ({ page }) => {
-    // ADAPTATION: app has no skip link; this test documents the a11y
-    // gap rather than failing. We assert: (1) no DOM element matches
-    // /skip.*main/i, and (2) pressing Tab once from a fresh page load
-    // focuses the first natural element (which is the sidebar
-    // toggle button, accessible name "Collapse sidebar").
+  test('34. Skip to main content link works on Tab from page load', async ({ page }) => {
+    // Issue #155: the app now ships a skip link as the first focusable
+    // element. On Tab from a fresh load focus lands on it; activating it
+    // moves focus to <main id="main-content">.
     const kb = new KeyboardNavPage(page)
     await kb.goto('/')
 
@@ -219,15 +217,16 @@ test.describe('Keyboard navigation, focus, ErrorBoundary, perf (#144)', () => {
         .map(el => (el.textContent || '').trim())
         .filter(t => /skip.*main/i.test(t))
     })
-    expect(skipCandidates).toEqual([])
+    expect(skipCandidates).toEqual(['Skip to main content'])
 
     await page.keyboard.press('Tab')
     const info = await kb.getActiveElementInfo()
-    expect(info.tag).not.toBe('BODY')
-    // The first natural focusable element is the sidebar collapse
-    // toggle (button with aria-label "Collapse sidebar").
-    expect(info.ariaLabel).not.toMatch(/skip.*main/i)
-    expect(info.text).not.toMatch(/skip.*main/i)
+    expect(info.tag).toBe('A')
+    expect(info.text).toMatch(/skip.*main/i)
+
+    await page.keyboard.press('Enter')
+    const focusedId = await page.evaluate(() => document.activeElement?.id ?? null)
+    expect(focusedId).toBe('main-content')
   })
 
   /* ── 35. Sidebar Enter + aria-current ─────────────────────── */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, useNavigate, useLocation, Navigate } from 'react-router-
 import { PageType } from './types'
 import SidebarNavigation from './components/SidebarNavigation'
 import SidebarToggle from './components/SidebarToggle'
+import SkipLink from './components/SkipLink'
 
 const Home = lazy(() => import('./pages/home/Home'))
 const Goal = lazy(() => import('./pages/goal/Goal'))
@@ -127,6 +128,7 @@ const AppShell: FC = () => {
   )
   return (
     <div className="app-layout">
+      <SkipLink />
       <ModernDesignToggle />
       {sidebarOpen && (
         <SidebarNavigation
@@ -139,6 +141,8 @@ const AppShell: FC = () => {
       )}
       {isMobile && sidebarOpen && <div onClick={() => setSidebarOpen(false)} className="sidebar-overlay" />}
       <main
+        id="main-content"
+        tabIndex={-1}
         className={`main-content${!sidebarOpen ? ' sidebar-closed' : ''}${!isMobile && sidebarOpen ? ' sidebar-open' : ''}`}
       >
         {!sidebarOpen && (

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -74,7 +74,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={true} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('Something went wrong on this page.')).toBeInTheDocument()
+    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
   })
 
@@ -84,7 +84,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={true} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('Something went wrong on this page.')).toBeInTheDocument()
+    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
 
     // Change ONLY resetKey — child still throws, but error state should reset first
     // then re-catch the new error. This proves resetKey triggers state reset.
@@ -94,7 +94,7 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     )
     // Error boundary reset → child rendered → child threw → caught again
-    expect(screen.getByText('Something went wrong on this page.')).toBeInTheDocument()
+    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
 
     // Now verify that changing resetKey with non-throwing child shows content
     rerender(
@@ -111,7 +111,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={true} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('Something went wrong on this page.')).toBeInTheDocument()
+    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
 
     // Rerender with same resetKey but non-throwing child — error should persist
     rerender(
@@ -119,7 +119,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={false} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('Something went wrong on this page.')).toBeInTheDocument()
+    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
   })
 
   it('logs to console.error via componentDidCatch', () => {
@@ -147,7 +147,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={true} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('Something went wrong on this page.')).toBeInTheDocument()
+    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
     expect(screen.queryByText('Reload page')).not.toBeInTheDocument()
     expect(screen.queryByText(/clear data/i)).not.toBeInTheDocument()
     expect(screen.queryByText('Show details')).not.toBeInTheDocument()
@@ -206,7 +206,7 @@ describe('ErrorBoundary', () => {
         <Conditional />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('Something went wrong on this page.')).toBeInTheDocument()
+    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
 
     // Set shouldThrow = false so that when Retry resets the boundary and
     // re-renders children, the component succeeds

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -74,8 +74,18 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={true} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
+    expect(screen.getByText("This card couldn't load.")).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+
+  it('card variant fallback is focusable with role="alert"', () => {
+    render(
+      <ErrorBoundary variant="card">
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveAttribute('tabindex', '0')
   })
 
   it('resets error state when resetKey changes (card variant)', () => {
@@ -84,7 +94,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={true} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
+    expect(screen.getByText("This card couldn't load.")).toBeInTheDocument()
 
     // Change ONLY resetKey — child still throws, but error state should reset first
     // then re-catch the new error. This proves resetKey triggers state reset.
@@ -94,7 +104,7 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     )
     // Error boundary reset → child rendered → child threw → caught again
-    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
+    expect(screen.getByText("This card couldn't load.")).toBeInTheDocument()
 
     // Now verify that changing resetKey with non-throwing child shows content
     rerender(
@@ -111,7 +121,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={true} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
+    expect(screen.getByText("This card couldn't load.")).toBeInTheDocument()
 
     // Rerender with same resetKey but non-throwing child — error should persist
     rerender(
@@ -119,7 +129,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={false} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
+    expect(screen.getByText("This card couldn't load.")).toBeInTheDocument()
   })
 
   it('logs to console.error via componentDidCatch', () => {
@@ -147,7 +157,7 @@ describe('ErrorBoundary', () => {
         <ThrowingComponent shouldThrow={true} />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
+    expect(screen.getByText("This card couldn't load.")).toBeInTheDocument()
     expect(screen.queryByText('Reload page')).not.toBeInTheDocument()
     expect(screen.queryByText(/clear data/i)).not.toBeInTheDocument()
     expect(screen.queryByText('Show details')).not.toBeInTheDocument()
@@ -206,7 +216,7 @@ describe('ErrorBoundary', () => {
         <Conditional />
       </ErrorBoundary>,
     )
-    expect(screen.getByText('This card couldn'"'"'t load.')).toBeInTheDocument()
+    expect(screen.getByText("This card couldn't load.")).toBeInTheDocument()
 
     // Set shouldThrow = false so that when Retry resets the boundary and
     // re-renders children, the component succeeds

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -99,8 +99,8 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
 
   renderCardFallback(): React.ReactNode {
     return (
-      <div className="error-boundary-card" role="alert">
-        <p>Something went wrong on this page.</p>
+      <div className="error-boundary-card" role="alert" tabIndex={0}>
+        <p>This card couldn&apos;t load.</p>
         <button className="error-boundary-card-btn" onClick={this.resetErrorBoundary}>
           Retry
         </button>

--- a/src/components/PassphraseInput.test.tsx
+++ b/src/components/PassphraseInput.test.tsx
@@ -94,10 +94,20 @@ describe('PassphraseInput', () => {
   })
 
   it('reserves space for error message even when no error', () => {
-    render(<PassphraseInput {...defaultProps} />)
-    const errorEl = screen.getByRole('alert')
+    const { container } = render(<PassphraseInput {...defaultProps} />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    const errorEl = container.querySelector('.unlock-error')
     expect(errorEl).toBeInTheDocument()
     expect(errorEl).toHaveTextContent('')
+    expect(errorEl).not.toHaveAttribute('role')
+    expect(errorEl).not.toHaveAttribute('aria-live')
+  })
+
+  it('exposes role="alert" only when error becomes non-empty', () => {
+    const { rerender } = render(<PassphraseInput {...defaultProps} />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    rerender(<PassphraseInput {...defaultProps} error="Wrong passphrase" />)
+    expect(screen.getByRole('alert')).toHaveTextContent('Wrong passphrase')
   })
 
   it('links aria-describedby to error and external description', () => {

--- a/src/components/PassphraseInput.tsx
+++ b/src/components/PassphraseInput.tsx
@@ -121,7 +121,12 @@ const PassphraseInput: FC<PassphraseInputProps> = ({
           {visible ? <EyeOffIcon /> : <EyeIcon />}
         </button>
       </div>
-      <p id={errorId} className="unlock-error" role="alert" aria-live="assertive">
+      <p
+        id={errorId}
+        className="unlock-error"
+        role={hasError ? 'alert' : undefined}
+        aria-live={hasError ? 'assertive' : undefined}
+      >
         {error || ''}
       </p>
     </div>

--- a/src/components/SkipLink.test.tsx
+++ b/src/components/SkipLink.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SkipLink from './SkipLink'
+
+describe('SkipLink', () => {
+  it('renders with text "Skip to main content" and href="#main-content"', () => {
+    render(<SkipLink />)
+    const link = screen.getByRole('link', { name: 'Skip to main content' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '#main-content')
+  })
+
+  it('is the first focusable element when tabbing from document.body', async () => {
+    const user = userEvent.setup()
+    render(<SkipLink />)
+    document.body.focus()
+    await user.tab()
+    expect(screen.getByRole('link', { name: 'Skip to main content' })).toHaveFocus()
+  })
+})

--- a/src/components/SkipLink.tsx
+++ b/src/components/SkipLink.tsx
@@ -1,0 +1,10 @@
+import { FC } from 'react'
+import '../styles/SkipLink.css'
+
+const SkipLink: FC = () => (
+  <a href="#main-content" className="skip-link">
+    Skip to main content
+  </a>
+)
+
+export default SkipLink

--- a/src/components/UnlockScreen.test.tsx
+++ b/src/components/UnlockScreen.test.tsx
@@ -108,7 +108,7 @@ describe('UnlockScreen', () => {
       expect(screen.getByRole('alert')).toHaveTextContent('Wrong passphrase. Please try again.')
     })
     await user.type(screen.getByLabelText('Passphrase'), 'n')
-    expect(screen.getByRole('alert')).toHaveTextContent('')
+    expect(screen.queryByRole('alert')).toBeNull()
   })
 
   it('shows unlock failed error on exception', async () => {

--- a/src/pages/drive/buildBudgetTree.test.ts
+++ b/src/pages/drive/buildBudgetTree.test.ts
@@ -6,15 +6,14 @@ beforeEach(() => {
 })
 
 describe('buildDriveTree', () => {
-  it('returns root Drive folder with Budget subfolder when no data', () => {
+  it('returns empty root Drive folder when no budget or tax data', () => {
     const tree = buildDriveTree()
     expect(tree.name).toBe('Drive')
     expect(tree.slug).toBe('')
     expect(tree.files).toEqual([])
-    // Should have at least Budget folder
-    const budget = tree.folders.find(f => f.slug === 'budget')
-    expect(budget).toBeTruthy()
-    expect(budget!.name).toBe('Budget')
+    // Budget folder is omitted when empty (parallel to Taxes)
+    expect(tree.folders.find(f => f.slug === 'budget')).toBeUndefined()
+    expect(tree.folders).toHaveLength(0)
   })
 
   it('builds year folders from budget CSVs', () => {
@@ -91,5 +90,37 @@ describe('buildDriveTree', () => {
     const taxes = tree.folders.find(f => f.slug === 'taxes')
     expect(taxes).toBeTruthy()
     expect(taxes!.folders).toHaveLength(1)
+  })
+
+  it('includes Budget folder only when budget files exist', () => {
+    // No budget data → Budget folder should be omitted
+    const tree = buildDriveTree()
+    expect(tree.folders.find(f => f.slug === 'budget')).toBeUndefined()
+
+    // Add a budget CSV → Budget folder should now appear
+    localStorage.setItem(
+      'budget-store',
+      JSON.stringify({
+        csvs: { '2025-01': { month: '2025-01', csv: 'date,amount\na,1', uploadedAt: '2025-01-15' } },
+        configs: {},
+        years: [2025],
+      }),
+    )
+    localStorage.setItem(
+      'budget-config',
+      JSON.stringify({
+        version: 1,
+        years: [2025],
+        categoryGroups: [
+          { id: 'others', name: 'Others', categories: [] },
+          { id: 'removed', name: 'Remove from Budget', categories: [] },
+        ],
+      }),
+    )
+
+    const tree2 = buildDriveTree()
+    const budget = tree2.folders.find(f => f.slug === 'budget')
+    expect(budget).toBeTruthy()
+    expect(budget!.folders).toHaveLength(1)
   })
 })

--- a/src/pages/drive/buildBudgetTree.ts
+++ b/src/pages/drive/buildBudgetTree.ts
@@ -26,15 +26,17 @@ export function buildDriveTree(): DriveFolder {
   }
   yearFolders.sort((a, b) => b.slug.localeCompare(a.slug))
 
-  const budgetFolder: DriveFolder = {
-    name: 'Budget',
-    slug: 'budget',
-    folders: yearFolders,
-    files: [],
+  const topFolders: DriveFolder[] = []
+  if (yearFolders.length > 0) {
+    topFolders.push({
+      name: 'Budget',
+      slug: 'budget',
+      folders: yearFolders,
+      files: [],
+    })
   }
 
   const taxFolder = buildTaxTree()
-  const topFolders: DriveFolder[] = [budgetFolder]
   if (taxFolder.folders.length > 0 || taxFolder.files.length > 0) {
     topFolders.push(taxFolder)
   }

--- a/src/pages/home/GoalsPeek.test.tsx
+++ b/src/pages/home/GoalsPeek.test.tsx
@@ -159,6 +159,54 @@ describe('GoalsPeek projection — no budget data', () => {
     renderPeek()
     expect(screen.getByText('Add budget data →')).toBeInTheDocument()
   })
+
+  it('renders the "Add budget data →" fallback as a focusable link to /budget', async () => {
+    const user = userEvent.setup()
+    const fiAcct = makeAccount(1, 'fi')
+    mockedUseData.mockReturnValue({
+      accounts: [fiAcct],
+      balances: [makeBalance(1, '2025-01', 500_000)],
+      allMonths: ['2025-01'],
+      setAccounts: () => {},
+      setBalances: () => {},
+    })
+    mockedGetSaveRate.mockReturnValue(null)
+    renderPeek()
+
+    const link = screen.getByRole('link', { name: 'Add budget data →' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('tabindex', '0')
+
+    await user.click(link)
+    expect(mockNavigate).toHaveBeenCalledWith('/budget')
+    // Parent goal-item button should NOT also navigate to /goal/1
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('activates the "Add budget data →" link with Enter and Space keys', async () => {
+    const user = userEvent.setup()
+    const fiAcct = makeAccount(1, 'fi')
+    mockedUseData.mockReturnValue({
+      accounts: [fiAcct],
+      balances: [makeBalance(1, '2025-01', 500_000)],
+      allMonths: ['2025-01'],
+      setAccounts: () => {},
+      setBalances: () => {},
+    })
+    mockedGetSaveRate.mockReturnValue(null)
+    renderPeek()
+
+    const link = screen.getByRole('link', { name: 'Add budget data →' })
+    link.focus()
+    expect(link).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+    expect(mockNavigate).toHaveBeenCalledWith('/budget')
+
+    mockNavigate.mockClear()
+    await user.keyboard(' ')
+    expect(mockNavigate).toHaveBeenCalledWith('/budget')
+  })
 })
 
 /* ═══════════════════════════════════════════════════════════════

--- a/src/pages/home/GoalsPeek.tsx
+++ b/src/pages/home/GoalsPeek.tsx
@@ -175,34 +175,52 @@ const GoalsPeek: FC<GoalsPeekProps> = ({ goals, gwGoals, onNavigate }) => {
             <button key={goal.id} className="goals-peek-item" onClick={() => navigate(`/goal/${goal.id}`)}>
               <div className="goals-peek-item-top">
                 <span className="goals-peek-name">{goal.goalName}</span>
-                {fiProjectedLabel && (
-                  <span
-                    className={`goals-peek-projected${
-                      fiProjectedType === 'reached'
-                        ? ' goals-peek-projected--reached'
-                        : fiProjectedType === 'no-budget'
-                          ? ' goals-peek-projected--link'
+                {fiProjectedLabel &&
+                  (fiProjectedType === 'no-budget' ? (
+                    <span
+                      role="link"
+                      tabIndex={0}
+                      className="goals-peek-projected goals-peek-projected--link goals-peek-projected--action"
+                      onClick={e => {
+                        e.stopPropagation()
+                        navigate('/budget')
+                      }}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          navigate('/budget')
+                        }
+                      }}
+                    >
+                      {fiProjectedLabel}
+                    </span>
+                  ) : (
+                    <span
+                      className={`goals-peek-projected${
+                        fiProjectedType === 'reached'
+                          ? ' goals-peek-projected--reached'
                           : fiProjectedType === 'not-reachable'
                             ? ' goals-peek-projected--warn'
                             : ''
-                    }`}
-                  >
-                    {fiProjectedType === 'date' ? (
-                      <>
-                        FI by <span className="goals-peek-projected-date">{fiProjectedLabel}</span>
-                      </>
-                    ) : fiProjectedType === 'reached' ? (
-                      <>
-                        <span role="img" aria-label="celebration">
-                          🎉
-                        </span>{' '}
-                        Goal reached!
-                      </>
-                    ) : (
-                      fiProjectedLabel
-                    )}
-                  </span>
-                )}
+                      }`}
+                    >
+                      {fiProjectedType === 'date' ? (
+                        <>
+                          FI by <span className="goals-peek-projected-date">{fiProjectedLabel}</span>
+                        </>
+                      ) : fiProjectedType === 'reached' ? (
+                        <>
+                          <span role="img" aria-label="celebration">
+                            🎉
+                          </span>{' '}
+                          Goal reached!
+                        </>
+                      ) : (
+                        fiProjectedLabel
+                      )}
+                    </span>
+                  ))}
               </div>
               <div className="goals-peek-bars">
                 <div className="goals-peek-bar-row">

--- a/src/pages/home/Home.test.tsx
+++ b/src/pages/home/Home.test.tsx
@@ -56,8 +56,15 @@ vi.mock('../../hooks/useTouchDrag', () => ({
 
 vi.mock('./NetWorthSummary', () => ({ default: () => <div data-testid="nw-card">Net Worth Card</div> }))
 vi.mock('./MiniCharts', () => ({ default: () => <div data-testid="charts-card">Charts Card</div> }))
-vi.mock('./GoalsPeek', () => ({ default: () => <div data-testid="goals-card">Goals Card</div> }))
+vi.mock('./GoalsPeek', () => ({
+  default: () => {
+    if (goalsPeekShouldThrow) throw new Error('GoalsPeek boom')
+    return <div data-testid="goals-card">Goals Card</div>
+  },
+}))
 vi.mock('./AllocationBreakdown', () => ({ default: () => <div data-testid="alloc-card">Allocation Card</div> }))
+
+let goalsPeekShouldThrow = false
 // Capture the SetupProgress mock so we can override it per-test
 let setupProgressImpl: FC<{ onDismiss: () => void }>
 vi.mock('./SetupProgress', () => ({
@@ -506,5 +513,32 @@ describe('Home hasBudgetData flag', () => {
     } as unknown as ReturnType<typeof useGoals>)
     renderHome()
     expect(screen.getByText('Setup guide')).toBeInTheDocument()
+  })
+})
+
+/* ═══════════════════════════════════════════════════════════════
+   Per-card ErrorBoundary isolation (#161)
+   ═══════════════════════════════════════════════════════════════ */
+
+describe('Home per-card error isolation', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    goalsPeekShouldThrow = false
+    vi.restoreAllMocks()
+  })
+
+  it('renders an inline error alert when one card throws but sibling cards still render', () => {
+    goalsPeekShouldThrow = true
+    renderHome()
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText("This card couldn't load.")).toBeInTheDocument()
+    expect(screen.queryByTestId('goals-card')).not.toBeInTheDocument()
+
+    expect(screen.getByTestId('nw-card')).toBeInTheDocument()
+    expect(screen.getByTestId('charts-card')).toBeInTheDocument()
+    expect(screen.getByTestId('alloc-card')).toBeInTheDocument()
   })
 })

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useGoals } from '../../contexts/GoalsContext'
 import { useData } from '../../contexts/DataContext'
 import { useTouchDrag } from '../../hooks/useTouchDrag'
+import ErrorBoundary from '../../components/ErrorBoundary'
 import NetWorthSummary from './NetWorthSummary'
 import MiniCharts from './MiniCharts'
 import GoalsPeek from './GoalsPeek'
@@ -152,28 +153,33 @@ const Home: FC = () => {
   }, [])
 
   const cards: ReactNode[] = [
-    <NetWorthSummary
-      key="nw"
-      accounts={accounts}
-      balances={balances}
-      allMonths={allMonths}
-      onNavigate={() => navigate('/net-worth')}
-    />,
-    <MiniCharts
-      key="charts"
-      accounts={accounts}
-      balances={balances}
-      balanceMap={balanceMap}
-      allMonths={allMonths}
-      onNavigate={() => navigate('/net-worth')}
-    />,
-    <GoalsPeek key="goals" goals={goals} gwGoals={gwGoals} onNavigate={() => navigate('/goal')} />,
-    <AllocationBreakdown
-      key="alloc"
-      accounts={accounts}
-      balances={balances}
-      onNavigate={() => navigate('/net-worth/allocation')}
-    />,
+    <ErrorBoundary key="nw" variant="card">
+      <NetWorthSummary
+        accounts={accounts}
+        balances={balances}
+        allMonths={allMonths}
+        onNavigate={() => navigate('/net-worth')}
+      />
+    </ErrorBoundary>,
+    <ErrorBoundary key="charts" variant="card">
+      <MiniCharts
+        accounts={accounts}
+        balances={balances}
+        balanceMap={balanceMap}
+        allMonths={allMonths}
+        onNavigate={() => navigate('/net-worth')}
+      />
+    </ErrorBoundary>,
+    <ErrorBoundary key="goals" variant="card">
+      <GoalsPeek goals={goals} gwGoals={gwGoals} onNavigate={() => navigate('/goal')} />
+    </ErrorBoundary>,
+    <ErrorBoundary key="alloc" variant="card">
+      <AllocationBreakdown
+        accounts={accounts}
+        balances={balances}
+        onNavigate={() => navigate('/net-worth/allocation')}
+      />
+    </ErrorBoundary>,
   ]
 
   return (

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -533,6 +533,17 @@
 .goals-peek-projected--link {
   color: var(--accent);
 }
+.goals-peek-projected--action {
+  cursor: pointer;
+  border-radius: var(--radius-sm, 0.25rem);
+}
+.goals-peek-projected--action:hover {
+  text-decoration: underline;
+}
+.goals-peek-projected--action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .goals-peek-projected--warn {
   color: var(--color-warning);
 }

--- a/src/styles/SkipLink.css
+++ b/src/styles/SkipLink.css
@@ -1,0 +1,22 @@
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 10000;
+  padding: 0.75rem 1rem;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: none;
+  border-radius: 0 0 0.3rem 0;
+  transform: translateY(-100%);
+  transition: transform 150ms ease-out;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
Batches five small UX/a11y cleanups.

- **#155** — SkipLink component (WCAG 2.4.1 Bypass Blocks); `<main>` gets `id="main-content"` + `tabIndex={-1}`.
- **#130** — PassphraseInput only exposes `role="alert"` / `aria-live` when there's actual error text.
- **#135** — Drive omits empty Budget folder so the empty-state UI renders on a fresh install.
- **#160** — GoalsPeek 'Add budget data →' fallback is now a real `role="link"` keyboard-activatable navigation control.
- **#161** — Each Home dashboard card individually wrapped in `<ErrorBoundary variant="card">` so one failing card no longer takes down siblings.

Plus a follow-up test commit aligning `UnlockScreen.test.tsx` with #130's conditional alert role.

tsc clean, lint clean, 2715 tests passing.

Fixes #130
Fixes #135
Fixes #155
Fixes #160
Fixes #161