### PR TITLE
fix: cleanup batch 2 (#129, #133, #145, #146, #149)

### DIFF
--- a/e2e/budget.spec.ts
+++ b/e2e/budget.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { BudgetPage } from './pages/budget.page'
 import {
   CURRENT_YEAR,

--- a/e2e/cross-page-encryption.spec.ts
+++ b/e2e/cross-page-encryption.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from './fixtures/base'
+import type { Page } from '@playwright/test'
 import { SecurityPage } from './pages/security.page'
 import { assertAllKeysAreEnvelopes, isEnvelope, PBKDF2_COST_MS, readEnvelope, SENSITIVE_KEYS } from './fixtures/encryption.fixtures'
 import {

--- a/e2e/cross-page-home.spec.ts
+++ b/e2e/cross-page-home.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from './fixtures/base'
+import type { Page } from '@playwright/test'
 import { buildV2Export, CROSS_PAGE_GOAL, mutateAccountBalance, seedCrossPage, URLS } from './fixtures/cross-page-data'
 import { waitForReload } from './fixtures/reload'
 

--- a/e2e/cross-page-import-export.spec.ts
+++ b/e2e/cross-page-import-export.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page, BrowserContext } from '@playwright/test'
+import { test, expect } from './fixtures/base'
+import type { Page, BrowserContext } from '@playwright/test'
 import {
   buildV2Export,
   CROSS_PAGE_ACCOUNTS,
@@ -68,8 +69,8 @@ import { SettingsPage } from './pages/settings.page'
  *      `isConfigured=false` and sync never fires. Test #10 verifies the
  *      realistic default-user navigation path WITHOUT any sync mocking
  *      and asserts no console errors and no calls to api.github.com
- *      (other than the feature-flags fetch we already route-mock in
- *      `seedOnce`). This is more valuable than a contrived "sync in
+ *      (other than the feature-flags fetch handled by the global base
+ *      fixture). This is more valuable than a contrived "sync in
  *      flight" mock — the original spec angle ("sync during nav") is
  *      not reachable from the default user state.
  *
@@ -122,18 +123,6 @@ interface SeedOverrides {
  * has already populated; tab-B does NOT need its own init script.
  */
 async function seedOnce(page: Page, overrides: SeedOverrides = {}): Promise<void> {
-  await page.route(
-    'https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json',
-    async route => {
-      const content = Buffer.from(JSON.stringify({ flags: {} })).toString('base64')
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ content, encoding: 'base64' }),
-      })
-    },
-  )
-
   const data = {
     profile: CROSS_PAGE_PROFILE,
     accounts: CROSS_PAGE_ACCOUNTS,
@@ -564,18 +553,21 @@ test.describe('Cross-page: Import/Export + Cross-tab + Dark Mode (#154)', () => 
     // verify the realistic contract: a user WITHOUT GitHub configured
     // can navigate every page without console errors and without any
     // call leaving the app to api.github.com beyond the feature-flags
-    // fetch we already route-mock in `seedOnce`.
+    // fetch handled by the global base fixture.
     const consoleErrors: string[] = []
     page.on('console', msg => {
       if (msg.type() === 'error') consoleErrors.push(msg.text())
     })
     const apiGitHubHits: string[] = []
     await page.route('https://api.github.com/**', async route => {
-      // Allow the seedOnce feature-flags route to win first; if anything
-      // else reaches api.github.com, record it and let it 404 so we
-      // don't accidentally hit the public rate limit during the suite.
+      // Let feature-flags requests fall through to the base fixture handler.
+      // Record and 404 everything else so we don't hit the public rate limit.
       const url = route.request().url()
-      if (!url.includes('feature-flags.json')) apiGitHubHits.push(url)
+      if (url.includes('feature-flags.json')) {
+        await route.fallback()
+        return
+      }
+      apiGitHubHits.push(url)
       await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' })
     })
 

--- a/e2e/cross-page-profile-tools.spec.ts
+++ b/e2e/cross-page-profile-tools.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from './fixtures/base'
+import type { Page } from '@playwright/test'
 import {
   mutateProfile,
   seedBudgetCsvsForYear,

--- a/e2e/drive.spec.ts
+++ b/e2e/drive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { DrivePage } from './pages/drive.page'
 import {
   APR_2024_CSV,

--- a/e2e/encryption.spec.ts
+++ b/e2e/encryption.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { SecurityPage } from './pages/security.page'
 import {
   PBKDF2_COST_MS,

--- a/e2e/fixtures/base.ts
+++ b/e2e/fixtures/base.ts
@@ -1,0 +1,38 @@
+import { test as base, expect } from '@playwright/test'
+
+/**
+ * Global feature-flags mock fixture (#146).
+ *
+ * Every e2e test automatically intercepts the GitHub Contents API call
+ * that FlagContext makes on mount:
+ *   GET https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json
+ *
+ * Without this mock, anonymous GitHub API rate-limits (403) leak into
+ * console-error assertions and slow down CI with real network calls.
+ *
+ * The mock returns `{ flags: {} }` (all flags at their coded defaults).
+ * Individual tests can still override with their own `page.route` call
+ * registered AFTER this one — Playwright uses last-registered-wins order.
+ */
+
+export const test = base.extend<{ featureFlagsMock: void }>({
+  featureFlagsMock: [
+    async ({ page }, use) => {
+      await page.route(
+        'https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json',
+        async route => {
+          const content = Buffer.from(JSON.stringify({ flags: {} })).toString('base64')
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ content, encoding: 'base64' }),
+          })
+        },
+      )
+      await use()
+    },
+    { auto: true },
+  ],
+})
+
+export { expect }

--- a/e2e/fixtures/cross-page-data.ts
+++ b/e2e/fixtures/cross-page-data.ts
@@ -4,9 +4,10 @@ import { assertAllKeysAreEnvelopes } from './encryption.fixtures'
 
 /**
  * Shared seed for the cross-page integration suites (#151 + future
- * 62b/c/d → #152/#153/#154). Centralizes the "all 13 sensitive keys
- * + feature-flags mock" baseline so each spec can layer overrides on
- * top without re-declaring 100 lines of localStorage seeding.
+ * 62b/c/d → #152/#153/#154). Centralizes the "all 13 sensitive keys"
+ * baseline so each spec can layer overrides on top without re-declaring
+ * 100 lines of localStorage seeding. The feature-flags mock is handled
+ * globally by the base fixture (`e2e/fixtures/base.ts`).
  *
  * Encryption is intentionally disabled (`encryption-enabled: '0'`),
  * which makes `appStorage.getJSON` read plaintext JSON directly out
@@ -175,26 +176,15 @@ export type SeedOverrides = Partial<{
 }>
 
 /**
- * Seed localStorage with the cross-page baseline. Mock the
- * feature-flags fetch (same pattern as seedNav) to keep test logs
- * free of GitHub anonymous-rate-limit 403s.
+ * Seed localStorage with the cross-page baseline.
+ *
+ * The feature-flags API mock is handled globally by the base fixture
+ * (`e2e/fixtures/base.ts`).
  *
  * Pass `null` for any field to OMIT that key from localStorage
  * (e.g. `{ budgetSummary: null }` → no `budget-summary` key written).
  */
 export async function seedCrossPage(page: Page, overrides: SeedOverrides = {}): Promise<void> {
-  await page.route(
-    'https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json',
-    async route => {
-      const content = Buffer.from(JSON.stringify({ flags: {} })).toString('base64')
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ content, encoding: 'base64' }),
-      })
-    },
-  )
-
   const resolved = {
     accounts: 'accounts' in overrides ? overrides.accounts : CROSS_PAGE_SEED.accounts,
     balances: 'balances' in overrides ? overrides.balances : CROSS_PAGE_SEED.balances,

--- a/e2e/fixtures/nav-data.ts
+++ b/e2e/fixtures/nav-data.ts
@@ -39,30 +39,15 @@ export function hashUrl(path: string): string {
  * or unlock screens. Uses `addInitScript` so it runs before app code on
  * every navigation (including reloads triggered inside the test).
  *
- * Also intercepts the public feature-flags fetch (`FlagContext` calls
- * `https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json`
- * on every mount). Without this mock the live GitHub API rate-limits
- * anonymous requests and returns 403, producing a console error that
- * leaks into console-error assertions (e.g., navigation.spec.ts test 13).
- * Lifting this to a global Playwright before-each is tracked separately.
+ * The feature-flags API mock is handled globally by the base fixture
+ * (`e2e/fixtures/base.ts`), so individual seed helpers no longer need
+ * to register their own route intercept.
  */
 export async function seedNav(page: Page, options: NavSeedOptions = {}): Promise<void> {
   const { profileName, extra } = options
   const profile = profileName
     ? JSON.stringify({ name: profileName, birthday: '', avatarDataUrl: '', partner: null })
     : null
-  await page.route(
-    'https://api.github.com/repos/dutta14/finance-tracking/contents/feature-flags.json',
-    async (route) => {
-      const emptyConfig = { flags: {} }
-      const content = Buffer.from(JSON.stringify(emptyConfig)).toString('base64')
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ content, encoding: 'base64' }),
-      })
-    },
-  )
   await page.addInitScript(
     ({ profile, extra }) => {
       localStorage.clear()

--- a/e2e/goal-projections.spec.ts
+++ b/e2e/goal-projections.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { GoalDetailPage } from './pages/goal-detail.page'
 import { HomePage } from './pages/home.page'
 import {

--- a/e2e/goals.spec.ts
+++ b/e2e/goals.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { GoalsPage } from './pages/goals.page'
 import {
   seedGoalsData,

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { HomePage } from './pages/home.page'
 import {
   seedHomeData,

--- a/e2e/keyboard-nav.spec.ts
+++ b/e2e/keyboard-nav.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { KeyboardNavPage, SIDEBAR_NAV_ORDER } from './pages/keyboard-nav.page'
 import { seedNav } from './fixtures/nav-data'
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, ConsoleMessage } from '@playwright/test'
+import { test, expect } from './fixtures/base'
+import type { ConsoleMessage } from '@playwright/test'
 import { NavigationPage, routeRegex } from './pages/navigation.page'
 import { hashUrl, NAV_PATHS, PAGE_HEADINGS, PRIMARY_NAV_LINKS, seedNav } from './fixtures/nav-data'
 

--- a/e2e/net-worth.spec.ts
+++ b/e2e/net-worth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { NetWorthPage } from './pages/net-worth.page'
 import {
   ACCOUNTS,

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { ResponsivePage, MAIN_PAGE_ROUTES } from './pages/responsive.page'
 import { seedNav, hashUrl } from './fixtures/nav-data'
 import { seedGoalsData } from './fixtures/goals.fixtures'

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { SearchPage } from './pages/search.page'
 import { seedNav } from './fixtures/nav-data'
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 import { SettingsPage } from './pages/settings.page'
 import {
   ALL_DATA_BALANCE,

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures/base'
 
 test.describe('Smoke tests', () => {
   test('renders the app with correct page title', async ({ page }) => {

--- a/e2e/taxes.spec.ts
+++ b/e2e/taxes.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from './fixtures/base'
+import type { Page } from '@playwright/test'
 import { TaxesPage } from './pages/taxes.page'
 import {
   CURRENT_YEAR,

--- a/src/components/SidebarNavigation.test.tsx
+++ b/src/components/SidebarNavigation.test.tsx
@@ -113,6 +113,34 @@ describe('SidebarNavigation', () => {
     expect(driveBtn).not.toHaveAttribute('aria-current')
   })
 
+  it('applies aria-current to Home button when currentPage is "home"', () => {
+    renderSidebar({ currentPage: 'home' })
+
+    const homeBtn = screen.getByRole('button', { name: 'Home' })
+    expect(homeBtn).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('applies aria-current to Net Worth button when currentPage is "net-worth"', () => {
+    renderSidebar({ currentPage: 'net-worth' })
+
+    const netWorthBtn = screen.getByRole('button', { name: 'Net Worth' })
+    expect(netWorthBtn).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('applies aria-current to Budget button when currentPage is "budget"', () => {
+    renderSidebar({ currentPage: 'budget' })
+
+    const budgetBtn = screen.getByRole('button', { name: 'Budget' })
+    expect(budgetBtn).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('applies aria-current to Taxes button when currentPage is "taxes"', () => {
+    renderSidebar({ currentPage: 'taxes' })
+
+    const taxesBtn = screen.getByRole('button', { name: 'Taxes' })
+    expect(taxesBtn).toHaveAttribute('aria-current', 'page')
+  })
+
   it('renders the footer group with correct ARIA attributes', () => {
     renderSidebar()
 

--- a/src/contexts/EncryptionContext.test.tsx
+++ b/src/contexts/EncryptionContext.test.tsx
@@ -708,8 +708,8 @@ describe('EncryptionContext', () => {
       }
     })
 
-    it('calls appStorage.disposeLocalState() and setMode("enabled") on remote-enable', () => {
-      const disposeSpy = vi.spyOn(appStorage, 'disposeLocalState')
+    it('calls appStorage.lockWithoutBroadcast() and setMode("enabled") on remote-enable', () => {
+      const disposeSpy = vi.spyOn(appStorage, 'lockWithoutBroadcast')
       const setModeSpy = vi.spyOn(appStorage, 'setMode')
       renderHook(() => useEncryption(), { wrapper })
 
@@ -722,9 +722,9 @@ describe('EncryptionContext', () => {
         window.dispatchEvent(new StorageEvent('storage', { key: 'encryption-enabled', newValue: '1', oldValue: null }))
       })
 
-      // disposeLocalState() is what clears _memoryStore + _pendingPersists
+      // lockWithoutBroadcast() is what clears _memoryStore + _pendingPersists
       // + _isReady. Without it, plaintext queued from disabled mode could
-      // leak. We use disposeLocalState rather than lock() to avoid emitting
+      // leak. We use lockWithoutBroadcast rather than lock() to avoid emitting
       // the cross-tab lock signal back to the tab that just enabled.
       expect(disposeSpy).toHaveBeenCalledTimes(1)
       expect(setModeSpy).toHaveBeenCalledWith('enabled')
@@ -733,9 +733,9 @@ describe('EncryptionContext', () => {
       setModeSpy.mockRestore()
     })
 
-    it('calls appStorage.disposeLocalState() and setMode("disabled") on remote-disable', () => {
+    it('calls appStorage.lockWithoutBroadcast() and setMode("disabled") on remote-disable', () => {
       localStorage.setItem('encryption-enabled', '1')
-      const disposeSpy = vi.spyOn(appStorage, 'disposeLocalState')
+      const disposeSpy = vi.spyOn(appStorage, 'lockWithoutBroadcast')
       const setModeSpy = vi.spyOn(appStorage, 'setMode')
       renderHook(() => useEncryption(), { wrapper })
 
@@ -754,14 +754,14 @@ describe('EncryptionContext', () => {
     })
 
     it('removes the storage listener on unmount (no handler fires after teardown)', () => {
-      const disposeSpy = vi.spyOn(appStorage, 'disposeLocalState')
+      const disposeSpy = vi.spyOn(appStorage, 'lockWithoutBroadcast')
       const { unmount } = renderHook(() => useEncryption(), { wrapper })
 
       unmount()
       disposeSpy.mockClear()
 
       // After unmount the listener must be gone — dispatching the event
-      // should not call appStorage.disposeLocalState(). If the cleanup ever
+      // should not call appStorage.lockWithoutBroadcast(). If the cleanup ever
       // breaks, this fires.
       act(() => {
         window.dispatchEvent(new StorageEvent('storage', { key: 'encryption-enabled', newValue: '1', oldValue: null }))

--- a/src/contexts/EncryptionContext.tsx
+++ b/src/contexts/EncryptionContext.tsx
@@ -117,15 +117,15 @@ export const EncryptionProvider: FC<{ children: ReactNode }> = ({ children }) =>
     const handler = (e: StorageEvent) => {
       if (e.key !== LS_ENABLED) return
       if (e.newValue === '1') {
-        // Disposal first: disposeLocalState() clears _memoryStore, drops
+        // Disposal first: lockWithoutBroadcast() clears _memoryStore, drops
         // _pendingPersists (so any queued plaintext write from disabled
         // mode cannot flush to LS after this point), and flips _isReady
         // to false. This closes the stale-tab plaintext gap that motivated
         // the listener — setCryptoKey(null) alone left _memoryStore and
-        // _pendingPersists intact. We use disposeLocalState rather than
+        // _pendingPersists intact. We use lockWithoutBroadcast rather than
         // lock() because lock() emits `_encryption-lock-signal` to other
         // tabs, which would loop back and lock the tab that just enabled.
-        appStorage.disposeLocalState()
+        appStorage.lockWithoutBroadcast()
         appStorage.setMode('enabled')
         setCryptoKey(null)
         setIsEncryptionEnabled(true)
@@ -133,7 +133,7 @@ export const EncryptionProvider: FC<{ children: ReactNode }> = ({ children }) =>
         // Same disposal for remote-disable: drop any queued persists tied
         // to the old enabled-mode cryptoKey and clear stale memory before
         // flipping to disabled mode.
-        appStorage.disposeLocalState()
+        appStorage.lockWithoutBroadcast()
         appStorage.setMode('disabled')
         setCryptoKey(null)
         setIsEncryptionEnabled(false)

--- a/src/styles/Budget.css
+++ b/src/styles/Budget.css
@@ -233,7 +233,7 @@ body.dark .budget-title {
   color: var(--color-text-heading);
 }
 .budget-table-wrapper {
-  overflow-x: hidden;
+  overflow-x: auto;
   max-width: 100%;
   border-radius: var(--radius);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);

--- a/src/utils/appStorage.ts
+++ b/src/utils/appStorage.ts
@@ -231,7 +231,7 @@ function lock(): void {
 }
 
 /**
- * Same disposal as `lock()` but does NOT write `_encryption-lock-signal`.
+ * Locks this tab locally without broadcasting the lock signal to other tabs.
  * Used by the EncryptionContext cross-tab listener when another tab toggles
  * `encryption-enabled`: this tab needs to clear its in-memory key, drop
  * queued plaintext persists, and flip `_isReady` to false — but emitting
@@ -242,7 +242,7 @@ function lock(): void {
  * queued plaintext write from disabled-mode flushes after this point),
  * nulls _cryptoKey, and sets _isReady = false.
  */
-function disposeLocalState(): void {
+function lockWithoutBroadcast(): void {
   for (const key of SENSITIVE_KEYS) {
     _memoryStore.delete(key)
     notifySubscribers(key, null)
@@ -287,7 +287,7 @@ export const appStorage = {
   subscribe,
   hydrate,
   lock,
-  disposeLocalState,
+  lockWithoutBroadcast,
   isReady,
   setMode,
   setCryptoKey,

--- a/src/utils/appStorage.ts
+++ b/src/utils/appStorage.ts
@@ -96,6 +96,7 @@ if (typeof window !== 'undefined') {
           }
         }
       } else if (_mode === 'disabled') {
+        if (e.newValue && isEncryptedEnvelope(e.newValue)) return
         _memoryStore.set(e.key, e.newValue)
         notifySubscribers(e.key, e.newValue)
       }


### PR DESCRIPTION
## Batch 2 Cleanup

Fixes #129 — cross-tab race: ignore encrypted envelopes when encryption disabled
Fixes #133 — rename `disposeLocalState` → `lockWithoutBroadcast`
Fixes #145 — add aria-current tests for sidebar navigation
Fixes #146 — lift feature-flags mock to global Playwright fixture
Fixes #149 — budget table overflow-x hidden → auto

### Changes
- **appStorage.ts**: `isEncryptedEnvelope` guard in cross-tab handler; renamed export
- **EncryptionContext.tsx**: updated call sites
- **SidebarNavigation.test.tsx**: 4 new aria-current tests
- **Budget.css**: overflow-x `auto` for horizontal scroll
- **e2e/fixtures/base.ts**: shared feature-flags mock fixture (18 spec files updated)

All 2719 unit tests pass. TypeScript compiles clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>