### PR TITLE
refactor: extract modules from useGitHubSync

### DIFF
--- a/src/hooks/base64Utils.test.ts
+++ b/src/hooks/base64Utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { toBase64, fromBase64 } from './base64Utils'
+
+describe('base64Utils', () => {
+  it('toBase64 then fromBase64 roundtrips ASCII', () => {
+    const csv = 'Date,Category,Amount\n2025-01-15,Groceries,42.50'
+    expect(fromBase64(toBase64(csv))).toBe(csv)
+  })
+
+  it('toBase64 then fromBase64 roundtrips UTF-8 with emoji', () => {
+    const text = 'Savings 💰 €100'
+    expect(fromBase64(toBase64(text))).toBe(text)
+  })
+
+  it('handles empty string', () => {
+    expect(toBase64('')).toBe('')
+    expect(fromBase64(toBase64(''))).toBe('')
+  })
+
+  it('fromBase64 throws on invalid input', () => {
+    expect(() => fromBase64('!!!not-base64!!!')).toThrow()
+  })
+})

--- a/src/hooks/base64Utils.ts
+++ b/src/hooks/base64Utils.ts
@@ -1,0 +1,14 @@
+export const toBase64 = (str: string): string => {
+  const bytes = new TextEncoder().encode(str)
+  let binary = ''
+  bytes.forEach(b => {
+    binary += String.fromCharCode(b)
+  })
+  return btoa(binary)
+}
+
+export const fromBase64 = (b64: string): string => {
+  const bin = atob(b64)
+  const bytes = Uint8Array.from(bin, c => c.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}

--- a/src/hooks/githubSyncApi.test.ts
+++ b/src/hooks/githubSyncApi.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { syncFileToGitHub, restoreFileFromGitHub } from './githubSyncApi'
+
+const mockApiHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'Content-Type': 'application/json',
+})
+
+describe('githubSyncApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const baseParams = {
+    token: 'ghp_test123',
+    owner: 'testuser',
+    repo: 'testrepo',
+    filePath: 'finance-goals.json',
+    apiHeaders: mockApiHeaders,
+  }
+
+  describe('syncFileToGitHub', () => {
+    it('creates file when SHA is null (PUT without sha field)', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(new Response(JSON.stringify({ content: { sha: 'abc123' } }), { status: 200 }))
+
+      await syncFileToGitHub({
+        ...baseParams,
+        data: { goals: [] },
+        defaultMessagePrefix: 'Auto-save',
+        getFileSha: async () => null,
+      })
+
+      const call = fetchSpy.mock.calls[0]
+      const body = JSON.parse(call[1]!.body as string)
+      expect(body.sha).toBeUndefined()
+      expect(body.content).toBeDefined()
+      expect(body.message).toContain('Auto-save')
+    })
+
+    it('updates file when SHA exists (PUT with sha)', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+
+      await syncFileToGitHub({
+        ...baseParams,
+        data: { goals: [] },
+        defaultMessagePrefix: 'Auto-save',
+        getFileSha: async () => 'existing-sha-456',
+      })
+
+      const call = fetchSpy.mock.calls[0]
+      const body = JSON.parse(call[1]!.body as string)
+      expect(body.sha).toBe('existing-sha-456')
+    })
+
+    it('retries on 409 with backoff, succeeds on second attempt', async () => {
+      vi.useFakeTimers()
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(new Response('', { status: 409 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+
+      const onSuccess = vi.fn()
+      const promise = syncFileToGitHub({
+        ...baseParams,
+        data: { goals: [] },
+        defaultMessagePrefix: 'Auto-save',
+        getFileSha: async () => 'sha1',
+        onSuccess,
+      })
+
+      await vi.advanceTimersByTimeAsync(1000)
+      await promise
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it('throws after 3 failed attempts', async () => {
+      vi.useFakeTimers()
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(new Response('', { status: 409 }))
+        .mockResolvedValueOnce(new Response('', { status: 409 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Conflict' }), { status: 409 }))
+
+      const onError = vi.fn()
+      const promise = syncFileToGitHub({
+        ...baseParams,
+        data: { goals: [] },
+        defaultMessagePrefix: 'Auto-save',
+        getFileSha: async () => 'sha1',
+        onError,
+      })
+
+      // Attach catch handler immediately to prevent unhandled rejection
+      const resultPromise = promise.catch(e => e)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(2000)
+
+      const error = await resultPromise
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message).toBe('Conflict')
+      expect(onError).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it('throws on 401 without retry', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'Bad credentials' }), { status: 401 }),
+      )
+
+      await expect(
+        syncFileToGitHub({
+          ...baseParams,
+          data: { goals: [] },
+          defaultMessagePrefix: 'Auto-save',
+          getFileSha: async () => null,
+        }),
+      ).rejects.toThrow('Bad credentials')
+    })
+
+    it('calls onSuccess callback on success', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+
+      const onSuccess = vi.fn()
+      await syncFileToGitHub({
+        ...baseParams,
+        data: { goals: [] },
+        defaultMessagePrefix: 'Auto-save',
+        getFileSha: async () => null,
+        onSuccess,
+      })
+
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('restoreFileFromGitHub', () => {
+    it('returns ok:true with decoded JSON data', async () => {
+      const data = { goals: [{ name: 'FI' }] }
+      const content = btoa(JSON.stringify(data))
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify({ content }), { status: 200 }))
+
+      const result = await restoreFileFromGitHub(baseParams)
+      expect(result.ok).toBe(true)
+      expect(result.data).toEqual(data)
+    })
+
+    it('returns ok:false on 404', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('', { status: 404 }))
+
+      const result = await restoreFileFromGitHub(baseParams)
+      expect(result.ok).toBe(false)
+      expect(result.data).toBeUndefined()
+    })
+
+    it('returns ok:false on malformed JSON', async () => {
+      const content = btoa('not valid json {{{')
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify({ content }), { status: 200 }))
+
+      const result = await restoreFileFromGitHub(baseParams)
+      expect(result.ok).toBe(false)
+    })
+  })
+})

--- a/src/hooks/githubSyncApi.ts
+++ b/src/hooks/githubSyncApi.ts
@@ -1,0 +1,96 @@
+import { toBase64 } from './base64Utils'
+
+export interface SyncFileParams {
+  token: string
+  owner: string
+  repo: string
+  filePath: string
+  data: object
+  message?: string
+  defaultMessagePrefix: string
+  getFileSha: () => Promise<string | null>
+  apiHeaders: (token: string) => Record<string, string>
+  onSuccess?: () => void
+  onError?: (error: Error) => void
+}
+
+export interface RestoreFileParams {
+  token: string
+  owner: string
+  repo: string
+  filePath: string
+  apiHeaders: (token: string) => Record<string, string>
+}
+
+export async function syncFileToGitHub(params: SyncFileParams): Promise<void> {
+  const {
+    token,
+    owner,
+    repo,
+    filePath,
+    data,
+    message,
+    defaultMessagePrefix,
+    getFileSha,
+    apiHeaders,
+    onSuccess,
+    onError,
+  } = params
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const prettyJson = JSON.stringify(data, null, 2)
+      const content = toBase64(prettyJson)
+      const sha = await getFileSha()
+      const commitMessage =
+        message ||
+        `${defaultMessagePrefix}: ${new Date().toLocaleString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        })}`
+      const body: Record<string, string> = { message: commitMessage, content }
+      if (sha) body.sha = sha
+      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`, {
+        method: 'PUT',
+        headers: apiHeaders(token),
+        body: JSON.stringify(body),
+      })
+      if ((res.status === 409 || res.status === 422) && attempt < 2) {
+        await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
+        continue
+      }
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
+      }
+      onSuccess?.()
+      return
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e))
+      if (attempt === 2) {
+        onError?.(error)
+        throw error
+      }
+    }
+  }
+}
+
+export async function restoreFileFromGitHub(params: RestoreFileParams): Promise<{ ok: boolean; data?: unknown }> {
+  const { token, owner, repo, filePath, apiHeaders } = params
+  try {
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`, {
+      headers: apiHeaders(token),
+    })
+    if (res.status === 404) return { ok: false }
+    if (!res.ok) return { ok: false }
+    const json = await res.json()
+    if (typeof json.content !== 'string') return { ok: false }
+    const parsed = JSON.parse(atob(json.content.replace(/\n/g, '')))
+    return { ok: true, data: parsed }
+  } catch {
+    return { ok: false }
+  }
+}

--- a/src/hooks/tokenCrypto.test.ts
+++ b/src/hooks/tokenCrypto.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { encryptToken, decryptToken } from './tokenCrypto'
+
+describe('tokenCrypto', () => {
+  const token = 'ghp_abc123TestToken'
+  const passphrase = 'my-secret-passphrase'
+
+  it('encryptToken returns distinct ciphertext, salt, and IV per call', async () => {
+    const a = await encryptToken(token, passphrase)
+    const b = await encryptToken(token, passphrase)
+    expect(a.encryptedToken).not.toBe(b.encryptedToken)
+    expect(a.tokenSalt).not.toBe(b.tokenSalt)
+    expect(a.tokenIv).not.toBe(b.tokenIv)
+  })
+
+  it('decryptToken recovers the original token', async () => {
+    const { encryptedToken: ct, tokenSalt, tokenIv } = await encryptToken(token, passphrase)
+    const result = await decryptToken(ct, passphrase, tokenSalt, tokenIv)
+    expect(result).toBe(token)
+  })
+
+  it('decryptToken throws on wrong passphrase', async () => {
+    const { encryptedToken: ct, tokenSalt, tokenIv } = await encryptToken(token, passphrase)
+    await expect(decryptToken(ct, 'wrong-passphrase', tokenSalt, tokenIv)).rejects.toThrow()
+  })
+
+  it('decryptToken throws on tampered IV', async () => {
+    const { encryptedToken: ct, tokenSalt, tokenIv } = await encryptToken(token, passphrase)
+    // Flip the first character of the IV to corrupt it
+    const tamperedIv = String.fromCharCode(tokenIv.charCodeAt(0) ^ 0xff) + tokenIv.slice(1)
+    await expect(decryptToken(ct, passphrase, tokenSalt, tamperedIv)).rejects.toThrow()
+  })
+})

--- a/src/hooks/tokenCrypto.ts
+++ b/src/hooks/tokenCrypto.ts
@@ -1,0 +1,31 @@
+import { deriveKey, bytesToB64, b64ToBytes } from '../utils/crypto'
+
+export const encryptToken = async (
+  token: string,
+  passphrase: string,
+): Promise<{ encryptedToken: string; tokenSalt: string; tokenIv: string }> => {
+  const salt = crypto.getRandomValues(new Uint8Array(16))
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const key = await deriveKey(passphrase, salt)
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(token))
+  return {
+    encryptedToken: bytesToB64(new Uint8Array(ciphertext)),
+    tokenSalt: bytesToB64(salt),
+    tokenIv: bytesToB64(iv),
+  }
+}
+
+export const decryptToken = async (
+  encryptedToken: string,
+  passphrase: string,
+  tokenSalt: string,
+  tokenIv: string,
+): Promise<string> => {
+  const key = await deriveKey(passphrase, b64ToBytes(tokenSalt))
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: b64ToBytes(tokenIv) },
+    key,
+    b64ToBytes(encryptedToken),
+  )
+  return new TextDecoder().decode(plaintext)
+}

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { getStorageItem, setStorageItem } from '../utils/storage'
-import { toBase64, fromBase64 } from './base64Utils'
+import { fromBase64 } from './base64Utils'
 import { encryptToken, decryptToken } from './tokenCrypto'
+import { syncFileToGitHub, restoreFileFromGitHub } from './githubSyncApi'
 
 export { toBase64, fromBase64 } from './base64Utils'
 
@@ -228,35 +229,17 @@ export const useGitHubSync = () => {
       if (!isConfigured) return
       setSyncStatus('syncing')
       setLastError(null)
-      let lastErr: Error | null = null // eslint-disable-line no-useless-assignment
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileSha()
-          const commitMessage =
-            message ||
-            `Auto-save: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${config.filePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
+      await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: config.filePath,
+        data,
+        message,
+        defaultMessagePrefix: 'Auto-save',
+        getFileSha,
+        apiHeaders,
+        onSuccess: () => {
           lastSyncedJsonRef.current = (() => {
             const { exportedAt: _, ...rest } = data as Record<string, unknown>
             return JSON.stringify(rest)
@@ -264,16 +247,12 @@ export const useGitHubSync = () => {
           setSyncStatus('success')
           setLastSyncAt(new Date().toISOString())
           clearDirty('goals')
-          return
-        } catch (e) {
-          lastErr = e instanceof Error ? e : new Error(String(e))
-          if (attempt === 2) {
-            setSyncStatus('error')
-            setLastError(lastErr.message)
-            throw lastErr
-          }
-        }
-      }
+        },
+        onError: error => {
+          setSyncStatus('error')
+          setLastError(error.message)
+        },
+      })
     },
     [activeToken, apiHeaders, config.owner, config.repo, config.filePath, getFileSha, isConfigured, clearDirty],
   )
@@ -281,48 +260,28 @@ export const useGitHubSync = () => {
   const syncDataNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileShaForPath(dataFilePath)
-          const commitMessage =
-            message ||
-            `Data sync: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${dataFilePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
+      await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: dataFilePath,
+        data,
+        message,
+        defaultMessagePrefix: 'Data sync',
+        getFileSha: () => getFileShaForPath(dataFilePath),
+        apiHeaders,
+        onSuccess: () => {
           lastSyncedDataJsonRef.current = (() => {
             const { exportedAt: _, ...rest } = data as Record<string, unknown>
             return JSON.stringify(rest)
           })()
           pendingDataFileRef.current = null
           clearDirty('data')
-          return
-        } catch (e) {
-          if (attempt === 2) {
-            console.error('Data file sync error:', e instanceof Error ? e.message : e)
-            throw e instanceof Error ? e : new Error(String(e))
-          }
-        }
-      }
+        },
+        onError: error => {
+          console.error('Data file sync error:', error.message)
+        },
+      })
     },
     [activeToken, apiHeaders, config.owner, config.repo, dataFilePath, getFileShaForPath, isConfigured, clearDirty],
   )
@@ -330,104 +289,58 @@ export const useGitHubSync = () => {
   const syncToolsNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileShaForPath(toolsFilePath)
-          const commitMessage =
-            message ||
-            `Tools sync: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${toolsFilePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
+      await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: toolsFilePath,
+        data,
+        message,
+        defaultMessagePrefix: 'Tools sync',
+        getFileSha: () => getFileShaForPath(toolsFilePath),
+        apiHeaders,
+        onSuccess: () => {
           clearDirty('tools')
-          return
-        } catch (e) {
-          if (attempt === 2) {
-            console.error('Tools file sync error:', e instanceof Error ? e.message : e)
-            throw e instanceof Error ? e : new Error(String(e))
-          }
-        }
-      }
+        },
+        onError: error => {
+          console.error('Tools file sync error:', error.message)
+        },
+      })
     },
     [activeToken, apiHeaders, config.owner, config.repo, toolsFilePath, getFileShaForPath, isConfigured, clearDirty],
   )
 
   const restoreToolsLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
     if (!isConfigured) return { ok: false }
-    try {
-      const res = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}/contents/${toolsFilePath}`, {
-        headers: apiHeaders(activeToken),
-      })
-      if (res.status === 404) return { ok: false }
-      if (!res.ok) return { ok: false }
-      const json = await res.json()
-      if (typeof json.content !== 'string') return { ok: false }
-      const parsed = JSON.parse(atob(json.content.replace(/\n/g, '')))
-      return { ok: true, data: parsed }
-    } catch {
-      return { ok: false }
-    }
+    return restoreFileFromGitHub({
+      token: activeToken,
+      owner: config.owner,
+      repo: config.repo,
+      filePath: toolsFilePath,
+      apiHeaders,
+    })
   }, [activeToken, apiHeaders, toolsFilePath, config.owner, config.repo, isConfigured])
 
   const syncAllocationNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileShaForPath(allocationFilePath)
-          const commitMessage =
-            message ||
-            `Allocation sync: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${allocationFilePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
+      await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: allocationFilePath,
+        data,
+        message,
+        defaultMessagePrefix: 'Allocation sync',
+        getFileSha: () => getFileShaForPath(allocationFilePath),
+        apiHeaders,
+        onSuccess: () => {
           clearDirty('allocation')
-          return
-        } catch (e) {
-          if (attempt === 2) {
-            console.error('Allocation file sync error:', e instanceof Error ? e.message : e)
-            throw e instanceof Error ? e : new Error(String(e))
-          }
-        }
-      }
+        },
+        onError: error => {
+          console.error('Allocation file sync error:', error.message)
+        },
+      })
     },
     [
       activeToken,
@@ -443,81 +356,49 @@ export const useGitHubSync = () => {
 
   const restoreAllocationLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
     if (!isConfigured) return { ok: false }
-    try {
-      const res = await fetch(
-        `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${allocationFilePath}`,
-        { headers: apiHeaders(activeToken) },
-      )
-      if (res.status === 404) return { ok: false }
-      if (!res.ok) return { ok: false }
-      const json = await res.json()
-      if (typeof json.content !== 'string') return { ok: false }
-      const parsed = JSON.parse(atob(json.content.replace(/\n/g, '')))
-      return { ok: true, data: parsed }
-    } catch {
-      return { ok: false }
-    }
+    return restoreFileFromGitHub({
+      token: activeToken,
+      owner: config.owner,
+      repo: config.repo,
+      filePath: allocationFilePath,
+      apiHeaders,
+    })
   }, [activeToken, apiHeaders, allocationFilePath, config.owner, config.repo, isConfigured])
 
   const syncTaxesNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileShaForPath(taxesFilePath)
-          const commitMessage =
-            message ||
-            `Taxes sync: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${taxesFilePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
+      await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: taxesFilePath,
+        data,
+        message,
+        defaultMessagePrefix: 'Taxes sync',
+        getFileSha: () => getFileShaForPath(taxesFilePath),
+        apiHeaders,
+        onSuccess: () => {
           clearDirty('taxes')
-          return
-        } catch (e) {
-          if (attempt === 2) {
-            console.error('Taxes file sync error:', e instanceof Error ? e.message : e)
-            throw e instanceof Error ? e : new Error(String(e))
-          }
-        }
-      }
+        },
+        onError: error => {
+          console.error('Taxes file sync error:', error.message)
+        },
+      })
     },
     [activeToken, apiHeaders, config.owner, config.repo, taxesFilePath, getFileShaForPath, isConfigured, clearDirty],
   )
 
   const restoreTaxesLatest = useCallback(async (): Promise<RestoreResult> => {
     if (!isConfigured) return { ok: false, message: '' }
-    try {
-      const res = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}/contents/${taxesFilePath}`, {
-        headers: apiHeaders(activeToken),
-      })
-      if (res.status === 404) return { ok: false, message: '' }
-      if (!res.ok) return { ok: false, message: '' }
-      const json = await res.json()
-      if (typeof json.content !== 'string') return { ok: false, message: '' }
-      const parsed = JSON.parse(atob(json.content.replace(/\n/g, '')))
-      return { ok: true, message: '', data: parsed }
-    } catch {
-      return { ok: false, message: '' }
-    }
+    const result = await restoreFileFromGitHub({
+      token: activeToken,
+      owner: config.owner,
+      repo: config.repo,
+      filePath: taxesFilePath,
+      apiHeaders,
+    })
+    return { ok: result.ok, message: '', data: result.data }
   }, [activeToken, apiHeaders, taxesFilePath, config.owner, config.repo, isConfigured])
 
   const fetchHistory = useCallback(async (): Promise<void> => {

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { deriveKey, bytesToB64, b64ToBytes } from '../utils/crypto'
 import { getStorageItem, setStorageItem } from '../utils/storage'
+import { toBase64, fromBase64 } from './base64Utils'
+
+export { toBase64, fromBase64 } from './base64Utils'
 
 export interface GitHubSyncConfig {
   owner: string
@@ -67,21 +70,6 @@ export const loadConfig = (): GitHubSyncConfig => {
   } catch {
     return DEFAULT_CONFIG
   }
-}
-
-export const toBase64 = (str: string): string => {
-  const bytes = new TextEncoder().encode(str)
-  let binary = ''
-  bytes.forEach(b => {
-    binary += String.fromCharCode(b)
-  })
-  return btoa(binary)
-}
-
-export const fromBase64 = (b64: string): string => {
-  const bin = atob(b64)
-  const bytes = Uint8Array.from(bin, c => c.charCodeAt(0))
-  return new TextDecoder().decode(bytes)
 }
 
 const encryptToken = async (

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { deriveKey, bytesToB64, b64ToBytes } from '../utils/crypto'
 import { getStorageItem, setStorageItem } from '../utils/storage'
 import { toBase64, fromBase64 } from './base64Utils'
+import { encryptToken, decryptToken } from './tokenCrypto'
 
 export { toBase64, fromBase64 } from './base64Utils'
 
@@ -70,36 +70,6 @@ export const loadConfig = (): GitHubSyncConfig => {
   } catch {
     return DEFAULT_CONFIG
   }
-}
-
-const encryptToken = async (
-  token: string,
-  passphrase: string,
-): Promise<{ encryptedToken: string; tokenSalt: string; tokenIv: string }> => {
-  const salt = crypto.getRandomValues(new Uint8Array(16))
-  const iv = crypto.getRandomValues(new Uint8Array(12))
-  const key = await deriveKey(passphrase, salt)
-  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(token))
-  return {
-    encryptedToken: bytesToB64(new Uint8Array(ciphertext)),
-    tokenSalt: bytesToB64(salt),
-    tokenIv: bytesToB64(iv),
-  }
-}
-
-const decryptToken = async (
-  encryptedToken: string,
-  passphrase: string,
-  tokenSalt: string,
-  tokenIv: string,
-): Promise<string> => {
-  const key = await deriveKey(passphrase, b64ToBytes(tokenSalt))
-  const plaintext = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: b64ToBytes(tokenIv) },
-    key,
-    b64ToBytes(encryptedToken),
-  )
-  return new TextDecoder().decode(plaintext)
 }
 
 export const useGitHubSync = () => {


### PR DESCRIPTION
Extracts 3 pure utility modules from the 806-line `useGitHubSync.ts` hook:

- **`base64Utils.ts`** — `toBase64` / `fromBase64` helpers
- **`tokenCrypto.ts`** — `encryptToken` / `decryptToken` (Web Crypto wrappers)
- **`githubSyncApi.ts`** — `syncFileToGitHub` / `restoreFileFromGitHub` (API calls + retry logic)

Result: 806 → 645 lines (~20% reduction). No behavioral changes — all 3307 unit tests and 332 E2E tests pass. Coverage remains above 90% on all axes.

Fixes #180