### PR TITLE
refactor(#180): Split useGitHubSync into focused modules

### DIFF
--- a/e2e/github-sync.spec.ts
+++ b/e2e/github-sync.spec.ts
@@ -1,0 +1,316 @@
+import { test, expect } from './fixtures/base'
+import { SettingsPage } from './pages/settings.page'
+
+/**
+ * Issue #180 — GitHub Sync refactor regression E2E (Journey 3).
+ *
+ * Verifies the full sync lifecycle through the UI: configure → test
+ * connection → sync → reload + re-unlock → restore. All GitHub API
+ * calls are intercepted via page.route so no real network is needed.
+ */
+
+const OWNER = 'test-user'
+const REPO = 'finance-backups'
+const TOKEN = 'ghp_testtoken1234567890abcdef'
+const PASSPHRASE = 'mysecurepassphrase'
+const GOALS_FILE = 'finance-goals.json'
+const DATA_FILE = 'finance-goals-data.json'
+const TOOLS_FILE = 'finance-goals-tools.json'
+const ALLOCATION_FILE = 'finance-goals-allocation.json'
+const TAXES_FILE = 'finance-goals-taxes.json'
+
+const GOAL_DATA = {
+  id: 1,
+  goalName: 'FI Target',
+  fiGoal: 2_000_000,
+  goalCreatedIn: 2024,
+  goalEndYear: 2050,
+  currentAmount: 100_000,
+  expenseValue2047: 80_000,
+  safeWithdrawalRate: 4,
+}
+
+/** Seed a minimal app state so there's data to sync. */
+async function seedForSync(page: import('@playwright/test').Page) {
+  await page.addInitScript(
+    payload => {
+      if (sessionStorage.getItem('__ghsync_e2e_seeded')) return
+      localStorage.clear()
+      localStorage.setItem('encryption-enabled', '0')
+      localStorage.setItem('onboarding-dismissed', '1')
+      localStorage.setItem('financialGoals', JSON.stringify([payload.goal]))
+      sessionStorage.setItem('__ghsync_e2e_seeded', '1')
+    },
+    { goal: GOAL_DATA },
+  )
+}
+
+/** Intercept all GitHub API calls with success responses. */
+async function mockGitHubApi(page: import('@playwright/test').Page) {
+  // Test connection: GET /repos/:owner/:repo
+  await page.route(
+    `https://api.github.com/repos/${OWNER}/${REPO}`,
+    async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          headers: { 'x-oauth-scopes': '' },
+          body: JSON.stringify({
+            full_name: `${OWNER}/${REPO}`,
+            private: true,
+            permissions: { push: true },
+          }),
+        })
+      } else {
+        await route.continue()
+      }
+    },
+  )
+
+  // Sync (PUT) and restore (GET) for all content files
+  const contentFiles = [GOALS_FILE, DATA_FILE, TOOLS_FILE, ALLOCATION_FILE, TAXES_FILE]
+  for (const file of contentFiles) {
+    await page.route(
+      `https://api.github.com/repos/${OWNER}/${REPO}/contents/${file}`,
+      async route => {
+        const method = route.request().method()
+        if (method === 'PUT') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              content: { sha: 'abc1234', name: file },
+              commit: { sha: 'def5678' },
+            }),
+          })
+        } else if (method === 'GET') {
+          const content = Buffer.from(
+            JSON.stringify(file === GOALS_FILE ? [GOAL_DATA] : {}),
+          ).toString('base64')
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ content, encoding: 'base64', sha: 'abc1234' }),
+          })
+        } else {
+          await route.continue()
+        }
+      },
+    )
+  }
+
+  // Commit history
+  await page.route(
+    `https://api.github.com/repos/${OWNER}/${REPO}/commits?path=${encodeURIComponent(GOALS_FILE)}&per_page=100`,
+    async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            sha: 'abc1234def5678abc1234def5678abc1234def567',
+            commit: {
+              message: 'Synced user data on Jan 1, 2025',
+              author: { date: '2025-01-01T12:00:00Z' },
+            },
+            html_url: `https://github.com/${OWNER}/${REPO}/commit/abc1234`,
+          },
+        ]),
+      })
+    },
+  )
+}
+
+/** Open Settings modal and navigate to the GitHub Sync tab. */
+async function openGitHubSyncTab(page: import('@playwright/test').Page) {
+  const settings = new SettingsPage(page)
+  await page.goto('/finance-tracking/')
+  await page.waitForLoadState('domcontentloaded')
+  await settings.settingsButton.click()
+  await expect(settings.dialog).toBeVisible()
+  const ghTab = settings.dialog.getByRole('tab', { name: 'GitHub Sync' })
+  await ghTab.click()
+  await expect(ghTab).toHaveAttribute('aria-selected', 'true')
+}
+
+/**
+ * Configure token + owner/repo and exit editing mode.
+ * After this, the repo-info view with Test/Sync buttons is visible.
+ */
+async function configureSync(page: import('@playwright/test').Page) {
+  const dialog = page.getByRole('dialog', { name: 'Settings' })
+
+  // Save encrypted token
+  await dialog.locator('.ghsync-token-input').first().fill(TOKEN)
+  await dialog.locator('.ghsync-passphrase-input').fill(PASSPHRASE)
+  await dialog.getByRole('button', { name: 'Save Token' }).click()
+  await expect(dialog.locator('.ghsync-result-success')).toContainText('Token encrypted and saved')
+
+  // Fill owner/repo
+  await dialog.locator('input[placeholder="your-github-username"]').fill(OWNER)
+  await dialog.locator('input[placeholder="finance-backups"]').fill(REPO)
+
+  // Exit editing mode (Cancel button appears once both fields are non-empty)
+  await dialog.locator('.ghsync-repo-cancel').click()
+  await expect(dialog.locator('.ghsync-repo-value')).toContainText(`${OWNER}/${REPO}`)
+}
+
+test.describe('GitHub Sync — Refactor Regression (#180)', () => {
+  test('full sync journey: configure → test connection → sync → restore roundtrip', async ({ page }) => {
+    await seedForSync(page)
+    await mockGitHubApi(page)
+    await openGitHubSyncTab(page)
+
+    const dialog = page.getByRole('dialog', { name: 'Settings' })
+
+    // Step 1-2: Configure token + repo
+    await configureSync(page)
+
+    // Step 3: Test connection → Connected badge
+    const testBtn = dialog.getByRole('button', { name: 'Test' })
+    await testBtn.click()
+    await expect(dialog.locator('.ghsync-connected-badge')).toBeVisible()
+    await expect(dialog.locator('.ghsync-connected-badge')).toHaveText('Connected')
+
+    // Step 4: Sync → status transitions to success
+    const syncBtn = dialog.locator('.ghsync-sync-now-btn')
+    await expect(syncBtn).toBeEnabled()
+    await syncBtn.click()
+    await expect(dialog.locator('.ghsync-status-dot--success')).toBeVisible({ timeout: 10_000 })
+
+    // Step 5: History tab → Restore Latest
+    await dialog.locator('.ghsync-tab-btn').filter({ hasText: 'History' }).click()
+    const restoreBtn = dialog.getByRole('button', { name: 'Restore Latest' })
+    await expect(restoreBtn).toBeVisible()
+    await restoreBtn.click()
+
+    // Restore triggers a state update that may close the modal.
+    // Wait for the restore operation to complete by checking data was applied.
+    await expect.poll(
+      () => page.evaluate(() => localStorage.getItem('financialGoals')),
+      { timeout: 10_000 },
+    ).not.toBeNull()
+    const goalData = await page.evaluate(() => localStorage.getItem('financialGoals'))
+    expect(JSON.parse(goalData!)[0].goalName).toBe('FI Target')
+  })
+
+  test('config persists across page reload and token can be re-unlocked', async ({ page }) => {
+    await seedForSync(page)
+    await mockGitHubApi(page)
+    await openGitHubSyncTab(page)
+
+    // Configure
+    await configureSync(page)
+
+    const dialog = page.getByRole('dialog', { name: 'Settings' })
+
+    // Close and reload
+    await dialog.getByRole('button', { name: 'Close' }).click()
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+
+    // Re-open Settings → GitHub Sync
+    const settings = new SettingsPage(page)
+    await settings.settingsButton.click()
+    await expect(settings.dialog).toBeVisible()
+    await settings.dialog.getByRole('tab', { name: 'GitHub Sync' }).click()
+
+    // Token is locked after reload — unlock it first
+    const unlockInput = dialog.locator('input[placeholder="Passphrase to unlock token"]')
+    await expect(unlockInput).toBeVisible()
+    await unlockInput.fill(PASSPHRASE)
+    await dialog.getByRole('button', { name: 'Unlock' }).click()
+
+    // Token unlocked status
+    await expect(dialog.locator('.ghsync-token-status')).toContainText('Token unlocked')
+
+    // Config persisted: repo info visible after unlock
+    await expect(dialog.locator('.ghsync-repo-value')).toContainText(`${OWNER}/${REPO}`)
+  })
+
+  test('sync status transitions from idle to syncing to success', async ({ page }) => {
+    await seedForSync(page)
+    await mockGitHubApi(page)
+    await openGitHubSyncTab(page)
+
+    const dialog = page.getByRole('dialog', { name: 'Settings' })
+
+    await configureSync(page)
+
+    // Initial: idle → Ready to sync
+    await expect(dialog.locator('.ghsync-status-dot--idle')).toBeVisible()
+    await expect(dialog.locator('.ghsync-status-bar')).toContainText('Ready to sync')
+
+    // Sync
+    await dialog.locator('.ghsync-sync-now-btn').click()
+
+    // After: success status
+    await expect(dialog.locator('.ghsync-status-dot--success')).toBeVisible({ timeout: 10_000 })
+    await expect(dialog.locator('.ghsync-status-bar')).toContainText('Last synced')
+  })
+
+  test('restore returns data that was previously synced and shows in history', async ({ page }) => {
+    await seedForSync(page)
+    await mockGitHubApi(page)
+    await openGitHubSyncTab(page)
+
+    const dialog = page.getByRole('dialog', { name: 'Settings' })
+
+    await configureSync(page)
+
+    // History tab
+    await dialog.locator('.ghsync-tab-btn').filter({ hasText: 'History' }).click()
+
+    // Mocked commit visible
+    await expect(dialog.locator('.ghsync-commit-message')).toContainText('Synced user data on Jan 1, 2025')
+
+    // Restore Latest
+    await dialog.getByRole('button', { name: 'Restore Latest' }).click()
+
+    // Restore triggers state update that may close modal — verify via localStorage
+    await expect.poll(
+      () => page.evaluate(() => {
+        const raw = localStorage.getItem('financialGoals')
+        if (!raw) return null
+        const goals = JSON.parse(raw)
+        return goals[0]?.goalName
+      }),
+      { timeout: 10_000 },
+    ).toBe('FI Target')
+
+    // Double-check full data integrity
+    const goalData = await page.evaluate(() => localStorage.getItem('financialGoals'))
+    const goals = JSON.parse(goalData!)
+    expect(goals).toHaveLength(1)
+    expect(goals[0].goalName).toBe('FI Target')
+  })
+
+  test('test connection shows error when repository is not found', async ({ page }) => {
+    await seedForSync(page)
+
+    // Override: 404 for repo
+    await page.route(
+      `https://api.github.com/repos/${OWNER}/${REPO}`,
+      async route => {
+        await route.fulfill({
+          status: 404,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Not Found' }),
+        })
+      },
+    )
+
+    await openGitHubSyncTab(page)
+
+    const dialog = page.getByRole('dialog', { name: 'Settings' })
+
+    await configureSync(page)
+
+    // Test connection → error
+    const testBtn = dialog.getByRole('button', { name: 'Test' })
+    await testBtn.click()
+    await expect(dialog.locator('.ghsync-result-error')).toContainText('Repository not found')
+    await expect(dialog.locator('.ghsync-connected-badge')).toHaveCount(0)
+  })
+})

--- a/src/contexts/GitHubSyncContext.tsx
+++ b/src/contexts/GitHubSyncContext.tsx
@@ -99,8 +99,8 @@ export const GitHubSyncProvider: FC<{ children: ReactNode }> = ({ children }) =>
     restoreLatest,
     restoreFromCommit,
     markRestored,
-    updateData: ghUpdateData,
-    updateDataFile: ghUpdateDataFile,
+    updateData: ghUpdateGoals,
+    updateDataFile: ghUpdateData,
     syncDataNow: ghSyncDataNow,
     restoreDataLatest,
     syncToolsNow: ghSyncToolsNow,
@@ -121,7 +121,7 @@ export const GitHubSyncProvider: FC<{ children: ReactNode }> = ({ children }) =>
 
   // Auto-sync whenever goals, gwGoals, profile, or themes change
   useEffect(() => {
-    ghUpdateData({
+    ghUpdateGoals({
       version: 2,
       exportedAt: new Date().toISOString(),
       goals,
@@ -145,9 +145,9 @@ export const GitHubSyncProvider: FC<{ children: ReactNode }> = ({ children }) =>
 
   const handleDataChange = useCallback(
     (accounts: Account[], balances: BalanceEntry[]): void => {
-      ghUpdateDataFile({ version: 1, exportedAt: new Date().toISOString(), accounts, balances })
+      ghUpdateData({ version: 1, exportedAt: new Date().toISOString(), accounts, balances })
     },
-    [ghUpdateDataFile],
+    [ghUpdateData],
   )
 
   const handleSyncNow = useCallback(

--- a/src/hooks/base64Utils.test.ts
+++ b/src/hooks/base64Utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { toBase64, fromBase64 } from './base64Utils'
+
+describe('base64Utils', () => {
+  it('toBase64 then fromBase64 roundtrips a UTF-8 string', () => {
+    const str = 'Hello, world! Café résumé naïve'
+    expect(fromBase64(toBase64(str))).toBe(str)
+  })
+
+  it('handles emoji and multi-byte characters', () => {
+    const str = '💰 Savings: €1,000 — 日本語テスト 🎉'
+    expect(fromBase64(toBase64(str))).toBe(str)
+  })
+
+  it('fromBase64 throws on invalid input', () => {
+    expect(() => fromBase64('!!!not-valid-base64!!!')).toThrow()
+  })
+})

--- a/src/hooks/base64Utils.ts
+++ b/src/hooks/base64Utils.ts
@@ -1,0 +1,14 @@
+export const toBase64 = (str: string): string => {
+  const bytes = new TextEncoder().encode(str)
+  let binary = ''
+  bytes.forEach(b => {
+    binary += String.fromCharCode(b)
+  })
+  return btoa(binary)
+}
+
+export const fromBase64 = (b64: string): string => {
+  const bin = atob(b64)
+  const bytes = Uint8Array.from(bin, c => c.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}

--- a/src/hooks/githubSyncConfig.ts
+++ b/src/hooks/githubSyncConfig.ts
@@ -1,0 +1,29 @@
+import type { GitHubSyncConfig } from './githubSyncTypes'
+import { getStorageItem, setStorageItem } from '../utils/storage'
+
+export const CONFIG_KEY = 'github-sync-config'
+
+export const DEFAULT_CONFIG: GitHubSyncConfig = {
+  owner: '',
+  repo: '',
+  filePath: 'finance-goals.json',
+  autoSync: false,
+}
+
+export const DEBOUNCE_MS = 60_000
+
+export const loadConfig = (): GitHubSyncConfig => {
+  try {
+    const parsed = { ...DEFAULT_CONFIG, ...getStorageItem('github-sync-config', DEFAULT_CONFIG) }
+    // Always use canonical file path — older configs may have a custom value
+    parsed.filePath = DEFAULT_CONFIG.filePath
+    // Strip legacy plaintext token if present
+    if ('legacyToken' in parsed) {
+      delete (parsed as Record<string, unknown>).legacyToken
+      setStorageItem('github-sync-config', parsed)
+    }
+    return parsed
+  } catch {
+    return DEFAULT_CONFIG
+  }
+}

--- a/src/hooks/githubSyncTypes.ts
+++ b/src/hooks/githubSyncTypes.ts
@@ -1,0 +1,40 @@
+export interface GitHubSyncConfig {
+  owner: string
+  repo: string
+  filePath: string
+  autoSync: boolean
+  encryptedToken?: string
+  tokenSalt?: string
+  tokenIv?: string
+}
+
+export interface CommitEntry {
+  sha: string
+  message: string
+  date: string
+  url: string
+}
+
+export interface ConnectionTestResult {
+  ok: boolean
+  message: string
+  warnings: string[]
+}
+
+export interface RestoreResult {
+  ok: boolean
+  message: string
+  data?: unknown
+}
+
+export type SyncStatus = 'idle' | 'syncing' | 'success' | 'error'
+
+export type SyncDomain = 'goals' | 'data' | 'tools' | 'allocation' | 'taxes' | 'budget'
+
+export interface SyncProgress {
+  total: number
+  completed: number
+  current: string
+  errors: string[]
+  domains: SyncDomain[]
+}

--- a/src/hooks/tokenCrypto.test.ts
+++ b/src/hooks/tokenCrypto.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { encryptToken, decryptToken } from './tokenCrypto'
+
+describe('tokenCrypto', () => {
+  const token = 'ghp_abc123XYZ_testToken'
+  const passphrase = 'my-secure-passphrase'
+
+  it('encryptToken returns distinct ciphertext, salt, and IV per call', async () => {
+    const result1 = await encryptToken(token, passphrase)
+    const result2 = await encryptToken(token, passphrase)
+
+    expect(result1.encryptedToken).toBeTruthy()
+    expect(result1.tokenSalt).toBeTruthy()
+    expect(result1.tokenIv).toBeTruthy()
+
+    expect(result1.encryptedToken).not.toBe(result2.encryptedToken)
+    expect(result1.tokenSalt).not.toBe(result2.tokenSalt)
+    expect(result1.tokenIv).not.toBe(result2.tokenIv)
+  })
+
+  it('decryptToken recovers the original token', async () => {
+    const { encryptedToken, tokenSalt, tokenIv } = await encryptToken(token, passphrase)
+    const decrypted = await decryptToken(encryptedToken, passphrase, tokenSalt, tokenIv)
+
+    expect(decrypted).toBe(token)
+  })
+
+  it('decryptToken throws on wrong passphrase', async () => {
+    const { encryptedToken, tokenSalt, tokenIv } = await encryptToken(token, passphrase)
+
+    await expect(decryptToken(encryptedToken, 'wrong-passphrase', tokenSalt, tokenIv)).rejects.toThrow()
+  })
+
+  it('decryptToken throws on tampered IV', async () => {
+    const { encryptedToken, tokenSalt, tokenIv } = await encryptToken(token, passphrase)
+    const tamperedIv = tokenIv.slice(0, -2) + 'AA'
+
+    await expect(decryptToken(encryptedToken, passphrase, tokenSalt, tamperedIv)).rejects.toThrow()
+  })
+})

--- a/src/hooks/tokenCrypto.ts
+++ b/src/hooks/tokenCrypto.ts
@@ -1,0 +1,31 @@
+import { deriveKey, bytesToB64, b64ToBytes } from '../utils/crypto'
+
+export const encryptToken = async (
+  token: string,
+  passphrase: string,
+): Promise<{ encryptedToken: string; tokenSalt: string; tokenIv: string }> => {
+  const salt = crypto.getRandomValues(new Uint8Array(16))
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const key = await deriveKey(passphrase, salt)
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(token))
+  return {
+    encryptedToken: bytesToB64(new Uint8Array(ciphertext)),
+    tokenSalt: bytesToB64(salt),
+    tokenIv: bytesToB64(iv),
+  }
+}
+
+export const decryptToken = async (
+  encryptedToken: string,
+  passphrase: string,
+  tokenSalt: string,
+  tokenIv: string,
+): Promise<string> => {
+  const key = await deriveKey(passphrase, b64ToBytes(tokenSalt))
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: b64ToBytes(tokenIv) },
+    key,
+    b64ToBytes(encryptedToken),
+  )
+  return new TextDecoder().decode(plaintext)
+}

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { deriveKey, bytesToB64, b64ToBytes } from '../utils/crypto'
+
 import { getStorageItem, setStorageItem } from '../utils/storage'
 import { toBase64, fromBase64 } from './base64Utils'
+import { encryptToken, decryptToken } from './tokenCrypto'
 export { toBase64, fromBase64 }
 
 export interface GitHubSyncConfig {
@@ -69,37 +70,6 @@ export const loadConfig = (): GitHubSyncConfig => {
   } catch {
     return DEFAULT_CONFIG
   }
-}
-
-
-const encryptToken = async (
-  token: string,
-  passphrase: string,
-): Promise<{ encryptedToken: string; tokenSalt: string; tokenIv: string }> => {
-  const salt = crypto.getRandomValues(new Uint8Array(16))
-  const iv = crypto.getRandomValues(new Uint8Array(12))
-  const key = await deriveKey(passphrase, salt)
-  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(token))
-  return {
-    encryptedToken: bytesToB64(new Uint8Array(ciphertext)),
-    tokenSalt: bytesToB64(salt),
-    tokenIv: bytesToB64(iv),
-  }
-}
-
-const decryptToken = async (
-  encryptedToken: string,
-  passphrase: string,
-  tokenSalt: string,
-  tokenIv: string,
-): Promise<string> => {
-  const key = await deriveKey(passphrase, b64ToBytes(tokenSalt))
-  const plaintext = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: b64ToBytes(tokenIv) },
-    key,
-    b64ToBytes(encryptedToken),
-  )
-  return new TextDecoder().decode(plaintext)
 }
 
 export const useGitHubSync = () => {

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -3,14 +3,10 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { setStorageItem } from '../utils/storage'
 import { toBase64, fromBase64 } from './base64Utils'
 import { encryptToken, decryptToken } from './tokenCrypto'
-import {
-  syncFileToGitHub,
-  restoreFileFromGitHub,
-  getFileShaForPathApi,
-  testConnectionApi,
-  fetchCommitHistory,
-} from './useGitHubSyncApi'
+import { getFileShaForPathApi } from './useGitHubSyncApi'
 import { CONFIG_KEY, DEBOUNCE_MS, loadConfig } from './githubSyncConfig'
+import { useGitHubSyncUpload } from './useGitHubSyncUpload'
+import { useGitHubSyncRestore } from './useGitHubSyncRestore'
 export { toBase64, fromBase64 }
 export { loadConfig }
 export type {
@@ -28,8 +24,6 @@ import type {
   SyncStatus,
   SyncDomain,
   SyncProgress,
-  RestoreResult,
-  ConnectionTestResult,
 } from './githubSyncTypes'
 
 export const useGitHubSync = () => {
@@ -74,12 +68,8 @@ export const useGitHubSync = () => {
     setDirtyFlags({ goals: false, data: false, tools: false, allocation: false, taxes: false, budget: false })
   }, [])
 
-  const pendingDataRef = useRef<object | null>(null)
-  const pendingDataFileRef = useRef<object | null>(null)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const dataDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const lastSyncedJsonRef = useRef<string | null>(null)
-  const lastSyncedDataJsonRef = useRef<string | null>(null)
 
   const hasStoredToken = !!config.encryptedToken
   const tokenUnlocked = !!sessionToken
@@ -152,257 +142,58 @@ export const useGitHubSync = () => {
     [activeToken, config.owner, config.repo],
   )
 
-  const syncNow = useCallback(
-    async (data: object, message?: string): Promise<void> => {
-      if (!isConfigured) return
-      setSyncStatus('syncing')
-      setLastError(null)
-      const result = await syncFileToGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: config.filePath,
-        data,
-        message,
-        messagePrefix: 'Auto-save',
-        getFileSha: () => getFileShaForPath(config.filePath),
-      })
-      if (result.ok) {
-        lastSyncedJsonRef.current = (() => {
-          const { exportedAt: _, ...rest } = data as Record<string, unknown>
-          return JSON.stringify(rest)
-        })()
-        setSyncStatus('success')
-        setLastSyncAt(new Date().toISOString())
-        clearDirty('goals')
-      } else {
-        setSyncStatus('error')
-        setLastError(result.error || 'Sync failed')
-        throw new Error(result.error || 'Sync failed')
-      }
-    },
-    [activeToken, config.owner, config.repo, config.filePath, getFileShaForPath, isConfigured, clearDirty],
-  )
+  const {
+    syncNow,
+    syncDataNow,
+    syncToolsNow,
+    syncAllocationNow,
+    syncTaxesNow,
+    lastSyncedJsonRef,
+    lastSyncedDataJsonRef,
+    pendingDataRef,
+    pendingDataFileRef,
+  } = useGitHubSyncUpload({
+    activeToken,
+    config,
+    isConfigured,
+    dataFilePath,
+    toolsFilePath,
+    allocationFilePath,
+    taxesFilePath,
+    getFileShaForPath,
+    clearDirty,
+    setSyncStatus,
+    setLastSyncAt,
+    setLastError,
+  })
 
-  const syncDataNow = useCallback(
-    async (data: object, message?: string): Promise<void> => {
-      if (!isConfigured) return
-      const result = await syncFileToGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: dataFilePath,
-        data,
-        message,
-        messagePrefix: 'Data sync',
-        getFileSha: () => getFileShaForPath(dataFilePath),
-      })
-      if (result.ok) {
-        lastSyncedDataJsonRef.current = (() => {
-          const { exportedAt: _, ...rest } = data as Record<string, unknown>
-          return JSON.stringify(rest)
-        })()
-        pendingDataFileRef.current = null
-        clearDirty('data')
-      } else {
-        console.error('Data file sync error:', result.error)
-        throw new Error(result.error || 'Data sync failed')
-      }
-    },
-    [activeToken, config.owner, config.repo, dataFilePath, getFileShaForPath, isConfigured, clearDirty],
-  )
+  const {
+    restoreLatest,
+    restoreDataLatest,
+    restoreToolsLatest,
+    restoreAllocationLatest,
+    restoreTaxesLatest,
+    restoreFromCommit,
+    markRestored: markRestoredRaw,
+    fetchHistory,
+    testConnection,
+  } = useGitHubSyncRestore({
+    activeToken,
+    config,
+    isConfigured,
+    dataFilePath,
+    toolsFilePath,
+    allocationFilePath,
+    taxesFilePath,
+    setHistory,
+    setSyncStatus,
+    setLastSyncAt,
+    setLastError,
+  })
 
-  const syncToolsNow = useCallback(
-    async (data: object, message?: string): Promise<void> => {
-      if (!isConfigured) return
-      const result = await syncFileToGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: toolsFilePath,
-        data,
-        message,
-        messagePrefix: 'Tools sync',
-        getFileSha: () => getFileShaForPath(toolsFilePath),
-      })
-      if (result.ok) {
-        clearDirty('tools')
-      } else {
-        console.error('Tools file sync error:', result.error)
-        throw new Error(result.error || 'Tools sync failed')
-      }
-    },
-    [activeToken, config.owner, config.repo, toolsFilePath, getFileShaForPath, isConfigured, clearDirty],
-  )
-
-  const restoreToolsLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
-    if (!isConfigured) return { ok: false }
-    try {
-      const result = await restoreFileFromGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: toolsFilePath,
-      })
-      return result.ok ? { ok: true, data: result.data } : { ok: false }
-    } catch {
-      return { ok: false }
-    }
-  }, [activeToken, config.owner, config.repo, toolsFilePath, isConfigured])
-
-  const syncAllocationNow = useCallback(
-    async (data: object, message?: string): Promise<void> => {
-      if (!isConfigured) return
-      const result = await syncFileToGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: allocationFilePath,
-        data,
-        message,
-        messagePrefix: 'Allocation sync',
-        getFileSha: () => getFileShaForPath(allocationFilePath),
-      })
-      if (result.ok) {
-        clearDirty('allocation')
-      } else {
-        console.error('Allocation file sync error:', result.error)
-        throw new Error(result.error || 'Allocation sync failed')
-      }
-    },
-    [activeToken, config.owner, config.repo, allocationFilePath, getFileShaForPath, isConfigured, clearDirty],
-  )
-
-  const restoreAllocationLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
-    if (!isConfigured) return { ok: false }
-    try {
-      const result = await restoreFileFromGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: allocationFilePath,
-      })
-      return result.ok ? { ok: true, data: result.data } : { ok: false }
-    } catch {
-      return { ok: false }
-    }
-  }, [activeToken, config.owner, config.repo, allocationFilePath, isConfigured])
-
-  const syncTaxesNow = useCallback(
-    async (data: object, message?: string): Promise<void> => {
-      if (!isConfigured) return
-      const result = await syncFileToGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: taxesFilePath,
-        data,
-        message,
-        messagePrefix: 'Taxes sync',
-        getFileSha: () => getFileShaForPath(taxesFilePath),
-      })
-      if (result.ok) {
-        clearDirty('taxes')
-      } else {
-        console.error('Taxes file sync error:', result.error)
-        throw new Error(result.error || 'Taxes sync failed')
-      }
-    },
-    [activeToken, config.owner, config.repo, taxesFilePath, getFileShaForPath, isConfigured, clearDirty],
-  )
-
-  const restoreTaxesLatest = useCallback(async (): Promise<RestoreResult> => {
-    if (!isConfigured) return { ok: false, message: '' }
-    try {
-      const result = await restoreFileFromGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: taxesFilePath,
-      })
-      return result.ok ? { ok: true, message: '', data: result.data } : { ok: false, message: '' }
-    } catch {
-      return { ok: false, message: '' }
-    }
-  }, [activeToken, config.owner, config.repo, taxesFilePath, isConfigured])
-
-  const fetchHistory = useCallback(async (): Promise<void> => {
-    if (!isConfigured) return
-    const commits = await fetchCommitHistory(activeToken, config.owner, config.repo, config.filePath)
-    setHistory(commits)
-  }, [activeToken, config.filePath, config.owner, config.repo, isConfigured])
-
-  const testConnection = useCallback(async (): Promise<ConnectionTestResult> => {
-    if (!activeToken || !config.owner || !config.repo) {
-      return { ok: false, message: 'Fill in token, owner, and repository first.', warnings: [] }
-    }
-    return testConnectionApi(activeToken, config.owner, config.repo)
-  }, [activeToken, config.owner, config.repo])
-
-  const restoreFromCommit = useCallback(
-    async (commitSha: string): Promise<RestoreResult> => {
-      if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
-      try {
-        const result = await restoreFileFromGitHub({
-          token: activeToken,
-          owner: config.owner,
-          repo: config.repo,
-          filePath: config.filePath,
-          ref: commitSha,
-          checkEncoding: true,
-        })
-        if (!result.ok) {
-          if (result.status === 404) return { ok: false, message: 'Backup file not found in this commit.' }
-          if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
-          return { ok: false, message: 'Backup file format is not supported.' }
-        }
-        return { ok: true, message: `Restored from commit ${commitSha.slice(0, 7)}.`, data: result.data }
-      } catch {
-        return { ok: false, message: 'Could not restore backup from GitHub.' }
-      }
-    },
-    [activeToken, config.filePath, config.owner, config.repo, isConfigured],
-  )
-
-  const restoreLatest = useCallback(async (): Promise<RestoreResult> => {
-    if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
-    try {
-      const result = await restoreFileFromGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: config.filePath,
-      })
-      if (!result.ok) {
-        if (result.status === 404) return { ok: false, message: 'Backup file not found in repository.' }
-        if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
-        return { ok: false, message: 'Backup file format is not supported.' }
-      }
-      return { ok: true, message: 'Latest backup restored from GitHub.', data: result.data }
-    } catch {
-      return { ok: false, message: 'Could not restore backup from GitHub.' }
-    }
-  }, [activeToken, config.owner, config.repo, config.filePath, isConfigured])
-
-  const restoreDataLatest = useCallback(async (): Promise<RestoreResult> => {
-    if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
-    try {
-      const result = await restoreFileFromGitHub({
-        token: activeToken,
-        owner: config.owner,
-        repo: config.repo,
-        filePath: dataFilePath,
-      })
-      if (!result.ok) {
-        if (result.status === 404) return { ok: true, message: 'No data file found.', data: null }
-        if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
-        return { ok: false, message: 'Data file format is not supported.' }
-      }
-      return { ok: true, message: 'Data file restored.', data: result.data }
-    } catch {
-      return { ok: false, message: 'Could not restore data file from GitHub.' }
-    }
-  }, [activeToken, config.owner, config.repo, dataFilePath, isConfigured])
+  const markRestored = useCallback(() => {
+    markRestoredRaw(clearAllDirty)
+  }, [markRestoredRaw, clearAllDirty])
 
   const updateData = useCallback(
     (data: object) => {
@@ -417,7 +208,7 @@ export const useGitHubSync = () => {
         if (pendingDataRef.current) syncNow(pendingDataRef.current).catch(() => {})
       }, DEBOUNCE_MS)
     },
-    [config.autoSync, isConfigured, syncNow, markDirty],
+    [config.autoSync, isConfigured, syncNow, markDirty, lastSyncedJsonRef, pendingDataRef],
   )
 
   const updateDataFile = useCallback(
@@ -433,15 +224,8 @@ export const useGitHubSync = () => {
         if (pendingDataFileRef.current) syncDataNow(pendingDataFileRef.current).catch(() => {})
       }, DEBOUNCE_MS)
     },
-    [config.autoSync, isConfigured, syncDataNow, markDirty],
+    [config.autoSync, isConfigured, syncDataNow, markDirty, lastSyncedDataJsonRef, pendingDataFileRef],
   )
-
-  const markRestored = useCallback(() => {
-    setLastSyncAt(new Date().toISOString())
-    setSyncStatus('success')
-    clearAllDirty()
-    setLastError(null)
-  }, [clearAllDirty])
 
   useEffect(
     () => () => {
@@ -470,7 +254,7 @@ export const useGitHubSync = () => {
     }
     document.addEventListener('visibilitychange', handleVisChange)
     return () => document.removeEventListener('visibilitychange', handleVisChange)
-  }, [isConfigured, activeToken, config, config.autoSync, syncNow, syncDataNow])
+  }, [isConfigured, activeToken, config, config.autoSync, syncNow, syncDataNow, pendingDataRef, pendingDataFileRef])
 
   return {
     config,

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { getStorageItem, setStorageItem } from '../utils/storage'
 import { toBase64, fromBase64 } from './base64Utils'
 import { encryptToken, decryptToken } from './tokenCrypto'
-import { syncFileToGitHub } from './useGitHubSyncApi'
+import { syncFileToGitHub, restoreFileFromGitHub } from './useGitHubSyncApi'
 export { toBase64, fromBase64 }
 
 export interface GitHubSyncConfig {
@@ -310,19 +310,15 @@ export const useGitHubSync = () => {
   const restoreToolsLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
     if (!isConfigured) return { ok: false }
     try {
-      const res = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}/contents/${toolsFilePath}`, {
-        headers: apiHeaders(activeToken),
+      const result = await restoreFileFromGitHub({
+        token: activeToken, owner: config.owner, repo: config.repo, filePath: toolsFilePath,
       })
-      if (res.status === 404) return { ok: false }
-      if (!res.ok) return { ok: false }
-      const json = await res.json()
-      if (typeof json.content !== 'string') return { ok: false }
-      const parsed = JSON.parse(atob(json.content.replace(/\n/g, '')))
-      return { ok: true, data: parsed }
+      if (!result.ok) return { ok: false }
+      return { ok: true, data: result.data }
     } catch {
       return { ok: false }
     }
-  }, [activeToken, apiHeaders, toolsFilePath, config.owner, config.repo, isConfigured])
+  }, [activeToken, config.owner, config.repo, toolsFilePath, isConfigured])
 
   const syncAllocationNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
@@ -350,20 +346,15 @@ export const useGitHubSync = () => {
   const restoreAllocationLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
     if (!isConfigured) return { ok: false }
     try {
-      const res = await fetch(
-        `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${allocationFilePath}`,
-        { headers: apiHeaders(activeToken) },
-      )
-      if (res.status === 404) return { ok: false }
-      if (!res.ok) return { ok: false }
-      const json = await res.json()
-      if (typeof json.content !== 'string') return { ok: false }
-      const parsed = JSON.parse(atob(json.content.replace(/\n/g, '')))
-      return { ok: true, data: parsed }
+      const result = await restoreFileFromGitHub({
+        token: activeToken, owner: config.owner, repo: config.repo, filePath: allocationFilePath,
+      })
+      if (!result.ok) return { ok: false }
+      return { ok: true, data: result.data }
     } catch {
       return { ok: false }
     }
-  }, [activeToken, apiHeaders, allocationFilePath, config.owner, config.repo, isConfigured])
+  }, [activeToken, config.owner, config.repo, allocationFilePath, isConfigured])
 
   const syncTaxesNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
@@ -391,19 +382,15 @@ export const useGitHubSync = () => {
   const restoreTaxesLatest = useCallback(async (): Promise<RestoreResult> => {
     if (!isConfigured) return { ok: false, message: '' }
     try {
-      const res = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}/contents/${taxesFilePath}`, {
-        headers: apiHeaders(activeToken),
+      const result = await restoreFileFromGitHub({
+        token: activeToken, owner: config.owner, repo: config.repo, filePath: taxesFilePath,
       })
-      if (res.status === 404) return { ok: false, message: '' }
-      if (!res.ok) return { ok: false, message: '' }
-      const json = await res.json()
-      if (typeof json.content !== 'string') return { ok: false, message: '' }
-      const parsed = JSON.parse(atob(json.content.replace(/\n/g, '')))
-      return { ok: true, message: '', data: parsed }
+      if (!result.ok) return { ok: false, message: '' }
+      return { ok: true, message: '', data: result.data }
     } catch {
       return { ok: false, message: '' }
     }
-  }, [activeToken, apiHeaders, taxesFilePath, config.owner, config.repo, isConfigured])
+  }, [activeToken, config.owner, config.repo, taxesFilePath, isConfigured])
 
   const fetchHistory = useCallback(async (): Promise<void> => {
     if (!isConfigured) return
@@ -497,43 +484,36 @@ export const useGitHubSync = () => {
   const restoreLatest = useCallback(async (): Promise<RestoreResult> => {
     if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
     try {
-      const res = await fetch(
-        `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${config.filePath}`,
-        { headers: apiHeaders(activeToken) },
-      )
-      if (res.status === 404) return { ok: false, message: 'Backup file not found in repository.' }
-      if (!res.ok) return { ok: false, message: `GitHub API error: ${res.status}` }
-      const file = (await res.json()) as { content?: string; encoding?: string }
-      if (!file.content || file.encoding !== 'base64') {
+      const result = await restoreFileFromGitHub({
+        token: activeToken, owner: config.owner, repo: config.repo, filePath: config.filePath,
+      })
+      if (!result.ok) {
+        if (result.status === 404) return { ok: false, message: 'Backup file not found in repository.' }
+        if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
         return { ok: false, message: 'Backup file format is not supported.' }
       }
-      const decoded = fromBase64(file.content.replace(/\n/g, ''))
-      const parsed = JSON.parse(decoded)
-      return { ok: true, message: 'Latest backup restored from GitHub.', data: parsed }
+      return { ok: true, message: 'Latest backup restored from GitHub.', data: result.data }
     } catch {
       return { ok: false, message: 'Could not restore backup from GitHub.' }
     }
-  }, [activeToken, apiHeaders, config.filePath, config.owner, config.repo, isConfigured])
+  }, [activeToken, config.owner, config.repo, config.filePath, isConfigured])
 
   const restoreDataLatest = useCallback(async (): Promise<RestoreResult> => {
     if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
     try {
-      const res = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}/contents/${dataFilePath}`, {
-        headers: apiHeaders(activeToken),
+      const result = await restoreFileFromGitHub({
+        token: activeToken, owner: config.owner, repo: config.repo, filePath: dataFilePath,
       })
-      if (res.status === 404) return { ok: true, message: 'No data file found.', data: null }
-      if (!res.ok) return { ok: false, message: `GitHub API error: ${res.status}` }
-      const file = (await res.json()) as { content?: string; encoding?: string }
-      if (!file.content || file.encoding !== 'base64') {
+      if (!result.ok) {
+        if (result.status === 404) return { ok: true, message: 'No data file found.', data: null }
+        if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
         return { ok: false, message: 'Data file format is not supported.' }
       }
-      const decoded = fromBase64(file.content.replace(/\n/g, ''))
-      const parsed = JSON.parse(decoded)
-      return { ok: true, message: 'Data file restored.', data: parsed }
+      return { ok: true, message: 'Data file restored.', data: result.data }
     } catch {
       return { ok: false, message: 'Could not restore data file from GitHub.' }
     }
-  }, [activeToken, apiHeaders, dataFilePath, config.owner, config.repo, isConfigured])
+  }, [activeToken, config.owner, config.repo, dataFilePath, isConfigured])
 
   const updateData = useCallback(
     (data: object) => {

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -1,77 +1,36 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 
-import { getStorageItem, setStorageItem } from '../utils/storage'
+import { setStorageItem } from '../utils/storage'
 import { toBase64, fromBase64 } from './base64Utils'
 import { encryptToken, decryptToken } from './tokenCrypto'
-import { syncFileToGitHub, restoreFileFromGitHub } from './useGitHubSyncApi'
+import {
+  syncFileToGitHub,
+  restoreFileFromGitHub,
+  getFileShaForPathApi,
+  testConnectionApi,
+  fetchCommitHistory,
+} from './useGitHubSyncApi'
+import { CONFIG_KEY, DEBOUNCE_MS, loadConfig } from './githubSyncConfig'
 export { toBase64, fromBase64 }
-
-export interface GitHubSyncConfig {
-  owner: string
-  repo: string
-  filePath: string
-  autoSync: boolean
-  encryptedToken?: string
-  tokenSalt?: string
-  tokenIv?: string
-}
-
-export interface CommitEntry {
-  sha: string
-  message: string
-  date: string
-  url: string
-}
-
-export interface ConnectionTestResult {
-  ok: boolean
-  message: string
-  warnings: string[]
-}
-
-export interface RestoreResult {
-  ok: boolean
-  message: string
-  data?: unknown
-}
-
-export type SyncStatus = 'idle' | 'syncing' | 'success' | 'error'
-
-export type SyncDomain = 'goals' | 'data' | 'tools' | 'allocation' | 'taxes' | 'budget'
-
-export interface SyncProgress {
-  total: number
-  completed: number
-  current: string
-  errors: string[]
-  domains: SyncDomain[]
-}
-
-const CONFIG_KEY = 'github-sync-config'
-const DEFAULT_CONFIG: GitHubSyncConfig = {
-  owner: '',
-  repo: '',
-  filePath: 'finance-goals.json',
-  autoSync: false,
-}
-
-const DEBOUNCE_MS = 60_000
-
-export const loadConfig = (): GitHubSyncConfig => {
-  try {
-    const parsed = { ...DEFAULT_CONFIG, ...getStorageItem('github-sync-config', DEFAULT_CONFIG) }
-    // Always use canonical file path — older configs may have a custom value
-    parsed.filePath = DEFAULT_CONFIG.filePath
-    // Strip legacy plaintext token if present
-    if ('legacyToken' in parsed) {
-      delete (parsed as Record<string, unknown>).legacyToken
-      setStorageItem('github-sync-config', parsed)
-    }
-    return parsed
-  } catch {
-    return DEFAULT_CONFIG
-  }
-}
+export { loadConfig }
+export type {
+  GitHubSyncConfig,
+  CommitEntry,
+  ConnectionTestResult,
+  RestoreResult,
+  SyncStatus,
+  SyncDomain,
+  SyncProgress,
+} from './githubSyncTypes'
+import type {
+  GitHubSyncConfig,
+  CommitEntry,
+  SyncStatus,
+  SyncDomain,
+  SyncProgress,
+  RestoreResult,
+  ConnectionTestResult,
+} from './githubSyncTypes'
 
 export const useGitHubSync = () => {
   const [config, setConfigState] = useState<GitHubSyncConfig>(loadConfig)
@@ -132,27 +91,14 @@ export const useGitHubSync = () => {
       const next = { ...prev, ...updates }
       try {
         setStorageItem('github-sync-config', next)
-        // Verify it was written successfully by reading it back
         const verify = localStorage.getItem(CONFIG_KEY)
-        if (!verify) {
-          console.warn('Failed to persist GitHub config to localStorage')
-        }
+        if (!verify) console.warn('Failed to persist GitHub config to localStorage')
       } catch (e) {
         console.error('Error saving GitHub config:', e)
       }
       return next
     })
   }, [])
-
-  const apiHeaders = useCallback(
-    (token: string): Record<string, string> => ({
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-      'Content-Type': 'application/json',
-    }),
-    [],
-  )
 
   const lockToken = useCallback(() => {
     setSessionToken('')
@@ -167,10 +113,7 @@ export const useGitHubSync = () => {
       try {
         const encrypted = await encryptToken(token.trim(), passphrase)
         setConfigState(prev => {
-          const next: GitHubSyncConfig = {
-            ...prev,
-            ...encrypted,
-          }
+          const next: GitHubSyncConfig = { ...prev, ...encrypted }
           setStorageItem('github-sync-config', next)
           return next
         })
@@ -205,24 +148,9 @@ export const useGitHubSync = () => {
   const taxesFilePath = config.filePath.replace(/\.json$/, '-taxes.json')
 
   const getFileShaForPath = useCallback(
-    async (path: string): Promise<string | null> => {
-      if (!activeToken) throw new Error('Token is not unlocked.')
-      const res = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}/contents/${path}`, {
-        headers: apiHeaders(activeToken),
-        cache: 'no-store',
-      })
-      if (res.status === 404) return null
-      if (res.status === 401) throw new Error('Invalid token — check the token is correct and not expired.')
-      if (!res.ok) throw new Error(`GitHub API error: ${res.status}`)
-      const data = await res.json()
-      return data.sha as string
-    },
-    [activeToken, config.owner, config.repo, apiHeaders],
+    (path: string) => getFileShaForPathApi(activeToken, config.owner, config.repo, path),
+    [activeToken, config.owner, config.repo],
   )
-
-  const getFileSha = useCallback(async (): Promise<string | null> => {
-    return getFileShaForPath(config.filePath)
-  }, [getFileShaForPath, config.filePath])
 
   const syncNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
@@ -237,7 +165,7 @@ export const useGitHubSync = () => {
         data,
         message,
         messagePrefix: 'Auto-save',
-        getFileSha,
+        getFileSha: () => getFileShaForPath(config.filePath),
       })
       if (result.ok) {
         lastSyncedJsonRef.current = (() => {
@@ -253,7 +181,7 @@ export const useGitHubSync = () => {
         throw new Error(result.error || 'Sync failed')
       }
     },
-    [activeToken, config.owner, config.repo, config.filePath, getFileSha, isConfigured, clearDirty],
+    [activeToken, config.owner, config.repo, config.filePath, getFileShaForPath, isConfigured, clearDirty],
   )
 
   const syncDataNow = useCallback(
@@ -311,10 +239,12 @@ export const useGitHubSync = () => {
     if (!isConfigured) return { ok: false }
     try {
       const result = await restoreFileFromGitHub({
-        token: activeToken, owner: config.owner, repo: config.repo, filePath: toolsFilePath,
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: toolsFilePath,
       })
-      if (!result.ok) return { ok: false }
-      return { ok: true, data: result.data }
+      return result.ok ? { ok: true, data: result.data } : { ok: false }
     } catch {
       return { ok: false }
     }
@@ -347,10 +277,12 @@ export const useGitHubSync = () => {
     if (!isConfigured) return { ok: false }
     try {
       const result = await restoreFileFromGitHub({
-        token: activeToken, owner: config.owner, repo: config.repo, filePath: allocationFilePath,
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: allocationFilePath,
       })
-      if (!result.ok) return { ok: false }
-      return { ok: true, data: result.data }
+      return result.ok ? { ok: true, data: result.data } : { ok: false }
     } catch {
       return { ok: false }
     }
@@ -383,10 +315,12 @@ export const useGitHubSync = () => {
     if (!isConfigured) return { ok: false, message: '' }
     try {
       const result = await restoreFileFromGitHub({
-        token: activeToken, owner: config.owner, repo: config.repo, filePath: taxesFilePath,
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: taxesFilePath,
       })
-      if (!result.ok) return { ok: false, message: '' }
-      return { ok: true, message: '', data: result.data }
+      return result.ok ? { ok: true, message: '', data: result.data } : { ok: false, message: '' }
     } catch {
       return { ok: false, message: '' }
     }
@@ -394,98 +328,50 @@ export const useGitHubSync = () => {
 
   const fetchHistory = useCallback(async (): Promise<void> => {
     if (!isConfigured) return
-    try {
-      const res = await fetch(
-        `https://api.github.com/repos/${config.owner}/${config.repo}/commits?path=${encodeURIComponent(config.filePath)}&per_page=100`,
-        { headers: apiHeaders(activeToken) },
-      )
-      if (!res.ok) return
-      const commits = await res.json()
-      setHistory(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (commits as any[]).map(c => ({
-          sha: (c.sha as string).slice(0, 7),
-          message: c.commit.message as string,
-          date: c.commit.author.date as string,
-          url: c.html_url as string,
-        })),
-      )
-    } catch {
-      // no-op
-    }
-  }, [activeToken, apiHeaders, config.filePath, config.owner, config.repo, isConfigured])
+    const commits = await fetchCommitHistory(activeToken, config.owner, config.repo, config.filePath)
+    setHistory(commits)
+  }, [activeToken, config.filePath, config.owner, config.repo, isConfigured])
 
   const testConnection = useCallback(async (): Promise<ConnectionTestResult> => {
     if (!activeToken || !config.owner || !config.repo) {
       return { ok: false, message: 'Fill in token, owner, and repository first.', warnings: [] }
     }
-    try {
-      const res = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}`, {
-        headers: apiHeaders(activeToken),
-      })
-      if (res.status === 404)
-        return {
-          ok: false,
-          message:
-            'Repository not found — if it\'s private, ensure the token has access to private repositories (classic token needs "repo" scope; fine-grained token needs "Contents: Read & Write").',
-          warnings: [],
-        }
-      if (res.status === 401)
-        return { ok: false, message: 'Invalid token — check the token is correct and not expired.', warnings: [] }
-      if (!res.ok) return { ok: false, message: `GitHub API error: ${res.status}`, warnings: [] }
-
-      const warnings: string[] = []
-      const scopes = res.headers.get('x-oauth-scopes')
-      const repoData = (await res.json()) as {
-        full_name: string
-        private?: boolean
-        permissions?: { push?: boolean }
-      }
-
-      if (repoData.private === false) {
-        warnings.push('This repository is public. Backups may expose sensitive financial data.')
-      }
-      if (repoData.permissions && repoData.permissions.push === false) {
-        warnings.push('Token does not appear to have write access to this repository.')
-      }
-      if (scopes && scopes.includes('repo')) {
-        warnings.push('Token has broad repo scope. Prefer a fine-grained token limited to one backup repo.')
-      }
-      return { ok: true, message: `Connected to ${repoData.full_name}`, warnings }
-    } catch {
-      return { ok: false, message: 'Network error. Check your connection.', warnings: [] }
-    }
-  }, [activeToken, apiHeaders, config.owner, config.repo])
+    return testConnectionApi(activeToken, config.owner, config.repo)
+  }, [activeToken, config.owner, config.repo])
 
   const restoreFromCommit = useCallback(
     async (commitSha: string): Promise<RestoreResult> => {
       if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
       try {
-        const res = await fetch(
-          `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${config.filePath}?ref=${commitSha}`,
-          { headers: apiHeaders(activeToken) },
-        )
-        if (res.status === 404) return { ok: false, message: 'Backup file not found in this commit.' }
-        if (!res.ok) return { ok: false, message: `GitHub API error: ${res.status}` }
-        const file = (await res.json()) as { content?: string; encoding?: string }
-        if (!file.content || file.encoding !== 'base64') {
+        const result = await restoreFileFromGitHub({
+          token: activeToken,
+          owner: config.owner,
+          repo: config.repo,
+          filePath: config.filePath,
+          ref: commitSha,
+          checkEncoding: true,
+        })
+        if (!result.ok) {
+          if (result.status === 404) return { ok: false, message: 'Backup file not found in this commit.' }
+          if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
           return { ok: false, message: 'Backup file format is not supported.' }
         }
-        const decoded = fromBase64(file.content.replace(/\n/g, ''))
-        const parsed = JSON.parse(decoded)
-        return { ok: true, message: `Restored from commit ${commitSha.slice(0, 7)}.`, data: parsed }
+        return { ok: true, message: `Restored from commit ${commitSha.slice(0, 7)}.`, data: result.data }
       } catch {
         return { ok: false, message: 'Could not restore backup from GitHub.' }
       }
     },
-    [activeToken, apiHeaders, config.filePath, config.owner, config.repo, isConfigured],
+    [activeToken, config.filePath, config.owner, config.repo, isConfigured],
   )
 
   const restoreLatest = useCallback(async (): Promise<RestoreResult> => {
     if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
     try {
       const result = await restoreFileFromGitHub({
-        token: activeToken, owner: config.owner, repo: config.repo, filePath: config.filePath,
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: config.filePath,
       })
       if (!result.ok) {
         if (result.status === 404) return { ok: false, message: 'Backup file not found in repository.' }
@@ -502,7 +388,10 @@ export const useGitHubSync = () => {
     if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
     try {
       const result = await restoreFileFromGitHub({
-        token: activeToken, owner: config.owner, repo: config.repo, filePath: dataFilePath,
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: dataFilePath,
       })
       if (!result.ok) {
         if (result.status === 404) return { ok: true, message: 'No data file found.', data: null }
@@ -519,9 +408,7 @@ export const useGitHubSync = () => {
     (data: object) => {
       const { exportedAt: _, ...rest } = data as Record<string, unknown>
       const json = JSON.stringify(rest)
-      if (json === lastSyncedJsonRef.current) {
-        return
-      }
+      if (json === lastSyncedJsonRef.current) return
       markDirty('goals')
       if (!config.autoSync || !isConfigured) return
       pendingDataRef.current = data

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -18,13 +18,7 @@ export type {
   SyncDomain,
   SyncProgress,
 } from './githubSyncTypes'
-import type {
-  GitHubSyncConfig,
-  CommitEntry,
-  SyncStatus,
-  SyncDomain,
-  SyncProgress,
-} from './githubSyncTypes'
+import type { GitHubSyncConfig, CommitEntry, SyncStatus, SyncDomain, SyncProgress } from './githubSyncTypes'
 
 export const useGitHubSync = () => {
   const [config, setConfigState] = useState<GitHubSyncConfig>(loadConfig)
@@ -254,7 +248,16 @@ export const useGitHubSync = () => {
     }
     document.addEventListener('visibilitychange', handleVisChange)
     return () => document.removeEventListener('visibilitychange', handleVisChange)
-  }, [isConfigured, activeToken, config, config.autoSync, syncGoalsNow, syncDataNow, pendingDataRef, pendingDataFileRef])
+  }, [
+    isConfigured,
+    activeToken,
+    config,
+    config.autoSync,
+    syncGoalsNow,
+    syncDataNow,
+    pendingDataRef,
+    pendingDataFileRef,
+  ])
 
   return {
     config,

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -327,54 +327,24 @@ export const useGitHubSync = () => {
   const syncAllocationNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileShaForPath(allocationFilePath)
-          const commitMessage =
-            message ||
-            `Allocation sync: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${allocationFilePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
-          clearDirty('allocation')
-          return
-        } catch (e) {
-          if (attempt === 2) {
-            console.error('Allocation file sync error:', e instanceof Error ? e.message : e)
-            throw e instanceof Error ? e : new Error(String(e))
-          }
-        }
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: allocationFilePath,
+        data,
+        message,
+        messagePrefix: 'Allocation sync',
+        getFileSha: () => getFileShaForPath(allocationFilePath),
+      })
+      if (result.ok) {
+        clearDirty('allocation')
+      } else {
+        console.error('Allocation file sync error:', result.error)
+        throw new Error(result.error || 'Allocation sync failed')
       }
     },
-    [
-      activeToken,
-      apiHeaders,
-      config.owner,
-      config.repo,
-      allocationFilePath,
-      getFileShaForPath,
-      isConfigured,
-      clearDirty,
-    ],
+    [activeToken, config.owner, config.repo, allocationFilePath, getFileShaForPath, isConfigured, clearDirty],
   )
 
   const restoreAllocationLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
@@ -398,45 +368,24 @@ export const useGitHubSync = () => {
   const syncTaxesNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileShaForPath(taxesFilePath)
-          const commitMessage =
-            message ||
-            `Taxes sync: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${taxesFilePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
-          clearDirty('taxes')
-          return
-        } catch (e) {
-          if (attempt === 2) {
-            console.error('Taxes file sync error:', e instanceof Error ? e.message : e)
-            throw e instanceof Error ? e : new Error(String(e))
-          }
-        }
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: taxesFilePath,
+        data,
+        message,
+        messagePrefix: 'Taxes sync',
+        getFileSha: () => getFileShaForPath(taxesFilePath),
+      })
+      if (result.ok) {
+        clearDirty('taxes')
+      } else {
+        console.error('Taxes file sync error:', result.error)
+        throw new Error(result.error || 'Taxes sync failed')
       }
     },
-    [activeToken, apiHeaders, config.owner, config.repo, taxesFilePath, getFileShaForPath, isConfigured, clearDirty],
+    [activeToken, config.owner, config.repo, taxesFilePath, getFileShaForPath, isConfigured, clearDirty],
   )
 
   const restoreTaxesLatest = useCallback(async (): Promise<RestoreResult> => {

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -143,12 +143,12 @@ export const useGitHubSync = () => {
   )
 
   const {
-    syncNow,
+    syncGoalsNow,
     syncDataNow,
     syncToolsNow,
     syncAllocationNow,
     syncTaxesNow,
-    lastSyncedJsonRef,
+    lastSyncedGoalsJsonRef,
     lastSyncedDataJsonRef,
     pendingDataRef,
     pendingDataFileRef,
@@ -168,7 +168,7 @@ export const useGitHubSync = () => {
   })
 
   const {
-    restoreLatest,
+    restoreGoalsLatest,
     restoreDataLatest,
     restoreToolsLatest,
     restoreAllocationLatest,
@@ -195,23 +195,23 @@ export const useGitHubSync = () => {
     markRestoredRaw(clearAllDirty)
   }, [markRestoredRaw, clearAllDirty])
 
-  const updateData = useCallback(
+  const updateGoals = useCallback(
     (data: object) => {
       const { exportedAt: _, ...rest } = data as Record<string, unknown>
       const json = JSON.stringify(rest)
-      if (json === lastSyncedJsonRef.current) return
+      if (json === lastSyncedGoalsJsonRef.current) return
       markDirty('goals')
       if (!config.autoSync || !isConfigured) return
       pendingDataRef.current = data
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
       debounceTimerRef.current = setTimeout(() => {
-        if (pendingDataRef.current) syncNow(pendingDataRef.current).catch(() => {})
+        if (pendingDataRef.current) syncGoalsNow(pendingDataRef.current).catch(() => {})
       }, DEBOUNCE_MS)
     },
-    [config.autoSync, isConfigured, syncNow, markDirty, lastSyncedJsonRef, pendingDataRef],
+    [config.autoSync, isConfigured, syncGoalsNow, markDirty, lastSyncedGoalsJsonRef, pendingDataRef],
   )
 
-  const updateDataFile = useCallback(
+  const updateData = useCallback(
     (data: object) => {
       const { exportedAt: _, ...rest } = data as Record<string, unknown>
       const json = JSON.stringify(rest)
@@ -248,13 +248,13 @@ export const useGitHubSync = () => {
           clearTimeout(dataDebounceTimerRef.current)
           dataDebounceTimerRef.current = null
         }
-        if (pendingDataRef.current) syncNow(pendingDataRef.current).catch(() => {})
+        if (pendingDataRef.current) syncGoalsNow(pendingDataRef.current).catch(() => {})
         if (pendingDataFileRef.current) syncDataNow(pendingDataFileRef.current).catch(() => {})
       }
     }
     document.addEventListener('visibilitychange', handleVisChange)
     return () => document.removeEventListener('visibilitychange', handleVisChange)
-  }, [isConfigured, activeToken, config, config.autoSync, syncNow, syncDataNow, pendingDataRef, pendingDataFileRef])
+  }, [isConfigured, activeToken, config, config.autoSync, syncGoalsNow, syncDataNow, pendingDataRef, pendingDataFileRef])
 
   return {
     config,
@@ -280,14 +280,14 @@ export const useGitHubSync = () => {
     saveEncryptedToken,
     unlockToken,
     lockToken,
-    syncNow,
+    syncNow: syncGoalsNow,
     fetchHistory,
     testConnection,
-    restoreLatest,
+    restoreLatest: restoreGoalsLatest,
     restoreFromCommit,
     markRestored,
-    updateData,
-    updateDataFile,
+    updateData: updateGoals,
+    updateDataFile: updateData,
     syncDataNow,
     syncToolsNow,
     syncAllocationNow,

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -259,50 +259,29 @@ export const useGitHubSync = () => {
   const syncDataNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileShaForPath(dataFilePath)
-          const commitMessage =
-            message ||
-            `Data sync: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${dataFilePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
-          lastSyncedDataJsonRef.current = (() => {
-            const { exportedAt: _, ...rest } = data as Record<string, unknown>
-            return JSON.stringify(rest)
-          })()
-          pendingDataFileRef.current = null
-          clearDirty('data')
-          return
-        } catch (e) {
-          if (attempt === 2) {
-            console.error('Data file sync error:', e instanceof Error ? e.message : e)
-            throw e instanceof Error ? e : new Error(String(e))
-          }
-        }
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: dataFilePath,
+        data,
+        message,
+        messagePrefix: 'Data sync',
+        getFileSha: () => getFileShaForPath(dataFilePath),
+      })
+      if (result.ok) {
+        lastSyncedDataJsonRef.current = (() => {
+          const { exportedAt: _, ...rest } = data as Record<string, unknown>
+          return JSON.stringify(rest)
+        })()
+        pendingDataFileRef.current = null
+        clearDirty('data')
+      } else {
+        console.error('Data file sync error:', result.error)
+        throw new Error(result.error || 'Data sync failed')
       }
     },
-    [activeToken, apiHeaders, config.owner, config.repo, dataFilePath, getFileShaForPath, isConfigured, clearDirty],
+    [activeToken, config.owner, config.repo, dataFilePath, getFileShaForPath, isConfigured, clearDirty],
   )
 
   const syncToolsNow = useCallback(

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { getStorageItem, setStorageItem } from '../utils/storage'
 import { toBase64, fromBase64 } from './base64Utils'
 import { encryptToken, decryptToken } from './tokenCrypto'
+import { syncFileToGitHub } from './useGitHubSyncApi'
 export { toBase64, fromBase64 }
 
 export interface GitHubSyncConfig {
@@ -228,54 +229,31 @@ export const useGitHubSync = () => {
       if (!isConfigured) return
       setSyncStatus('syncing')
       setLastError(null)
-      let lastErr: Error | null = null // eslint-disable-line no-useless-assignment
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileSha()
-          const commitMessage =
-            message ||
-            `Auto-save: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${config.filePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
-          lastSyncedJsonRef.current = (() => {
-            const { exportedAt: _, ...rest } = data as Record<string, unknown>
-            return JSON.stringify(rest)
-          })()
-          setSyncStatus('success')
-          setLastSyncAt(new Date().toISOString())
-          clearDirty('goals')
-          return
-        } catch (e) {
-          lastErr = e instanceof Error ? e : new Error(String(e))
-          if (attempt === 2) {
-            setSyncStatus('error')
-            setLastError(lastErr.message)
-            throw lastErr
-          }
-        }
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: config.filePath,
+        data,
+        message,
+        messagePrefix: 'Auto-save',
+        getFileSha,
+      })
+      if (result.ok) {
+        lastSyncedJsonRef.current = (() => {
+          const { exportedAt: _, ...rest } = data as Record<string, unknown>
+          return JSON.stringify(rest)
+        })()
+        setSyncStatus('success')
+        setLastSyncAt(new Date().toISOString())
+        clearDirty('goals')
+      } else {
+        setSyncStatus('error')
+        setLastError(result.error || 'Sync failed')
+        throw new Error(result.error || 'Sync failed')
       }
     },
-    [activeToken, apiHeaders, config.owner, config.repo, config.filePath, getFileSha, isConfigured, clearDirty],
+    [activeToken, config.owner, config.repo, config.filePath, getFileSha, isConfigured, clearDirty],
   )
 
   const syncDataNow = useCallback(

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -287,45 +287,24 @@ export const useGitHubSync = () => {
   const syncToolsNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const prettyJson = JSON.stringify(data, null, 2)
-          const content = toBase64(prettyJson)
-          const sha = await getFileShaForPath(toolsFilePath)
-          const commitMessage =
-            message ||
-            `Tools sync: ${new Date().toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}`
-          const body: Record<string, string> = { message: commitMessage, content }
-          if (sha) body.sha = sha
-          const res = await fetch(
-            `https://api.github.com/repos/${config.owner}/${config.repo}/contents/${toolsFilePath}`,
-            { method: 'PUT', headers: apiHeaders(activeToken), body: JSON.stringify(body) },
-          )
-          if ((res.status === 409 || res.status === 422) && attempt < 2) {
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-            continue
-          }
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}))
-            throw new Error((err as { message?: string }).message || `GitHub API error: ${res.status}`)
-          }
-          clearDirty('tools')
-          return
-        } catch (e) {
-          if (attempt === 2) {
-            console.error('Tools file sync error:', e instanceof Error ? e.message : e)
-            throw e instanceof Error ? e : new Error(String(e))
-          }
-        }
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: toolsFilePath,
+        data,
+        message,
+        messagePrefix: 'Tools sync',
+        getFileSha: () => getFileShaForPath(toolsFilePath),
+      })
+      if (result.ok) {
+        clearDirty('tools')
+      } else {
+        console.error('Tools file sync error:', result.error)
+        throw new Error(result.error || 'Tools sync failed')
       }
     },
-    [activeToken, apiHeaders, config.owner, config.repo, toolsFilePath, getFileShaForPath, isConfigured, clearDirty],
+    [activeToken, config.owner, config.repo, toolsFilePath, getFileShaForPath, isConfigured, clearDirty],
   )
 
   const restoreToolsLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {

--- a/src/hooks/useGitHubSync.ts
+++ b/src/hooks/useGitHubSync.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { deriveKey, bytesToB64, b64ToBytes } from '../utils/crypto'
 import { getStorageItem, setStorageItem } from '../utils/storage'
+import { toBase64, fromBase64 } from './base64Utils'
+export { toBase64, fromBase64 }
 
 export interface GitHubSyncConfig {
   owner: string
@@ -69,20 +71,6 @@ export const loadConfig = (): GitHubSyncConfig => {
   }
 }
 
-export const toBase64 = (str: string): string => {
-  const bytes = new TextEncoder().encode(str)
-  let binary = ''
-  bytes.forEach(b => {
-    binary += String.fromCharCode(b)
-  })
-  return btoa(binary)
-}
-
-export const fromBase64 = (b64: string): string => {
-  const bin = atob(b64)
-  const bytes = Uint8Array.from(bin, c => c.charCodeAt(0))
-  return new TextDecoder().decode(bytes)
-}
 
 const encryptToken = async (
   token: string,

--- a/src/hooks/useGitHubSyncApi.test.ts
+++ b/src/hooks/useGitHubSyncApi.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { toBase64 } from './base64Utils'
+import {
+  syncFileToGitHub,
+  restoreFileFromGitHub,
+  getFileShaForPathApi,
+  testConnectionApi,
+  fetchCommitHistory,
+} from './useGitHubSyncApi'
+import type { SyncFileParams } from './useGitHubSyncApi'
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+const baseParams: SyncFileParams = {
+  token: 'ghp_test',
+  owner: 'testowner',
+  repo: 'testrepo',
+  filePath: 'data/finance.json',
+  data: { accounts: [] },
+  messagePrefix: 'sync',
+  getFileSha: vi.fn().mockResolvedValue(null),
+}
+
+describe('syncFileToGitHub', () => {
+  it('syncFileToGitHub: creates file when SHA is null (PUT, no sha)', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 })
+
+    const result = await syncFileToGitHub(baseParams)
+
+    expect(result).toEqual({ ok: true })
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(callBody.sha).toBeUndefined()
+    expect(callBody.content).toBeTruthy()
+    expect(callBody.message).toContain('sync')
+    expect(mockFetch.mock.calls[0][1].method).toBe('PUT')
+  })
+
+  it('syncFileToGitHub: updates file when SHA exists (PUT with sha)', async () => {
+    mockFetch.mockReset()
+    const params = { ...baseParams, getFileSha: vi.fn().mockResolvedValue('abc123') }
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 })
+
+    const result = await syncFileToGitHub(params)
+
+    expect(result).toEqual({ ok: true })
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(callBody.sha).toBe('abc123')
+  })
+
+  it('syncFileToGitHub: retries once on 409 with fresh SHA', async () => {
+    mockFetch.mockReset()
+    const getFileSha = vi.fn().mockResolvedValueOnce('old-sha').mockResolvedValueOnce('new-sha')
+    const params = { ...baseParams, getFileSha }
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 409, json: async () => ({ message: 'conflict' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+
+    const promise = syncFileToGitHub(params)
+    await vi.advanceTimersByTimeAsync(5000)
+    const result = await promise
+
+    expect(result).toEqual({ ok: true })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(getFileSha).toHaveBeenCalledTimes(2)
+  })
+
+  it('syncFileToGitHub: returns ok:false with error on 401', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ message: 'Bad credentials' }),
+    })
+
+    const result = await syncFileToGitHub(baseParams)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('Bad credentials')
+  })
+})
+
+describe('restoreFileFromGitHub', () => {
+  const restoreParams = {
+    token: 'ghp_test',
+    owner: 'testowner',
+    repo: 'testrepo',
+    filePath: 'data/finance.json',
+  }
+
+  it('restoreFileFromGitHub: returns ok:false on 404', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const result = await restoreFileFromGitHub(restoreParams)
+
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(404)
+  })
+
+  it('restoreFileFromGitHub: decodes base64 content and parses JSON', async () => {
+    const payload = { accounts: [{ name: 'Checking' }] }
+    const encoded = toBase64(JSON.stringify(payload))
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ content: encoded, encoding: 'base64' }),
+    })
+
+    const result = await restoreFileFromGitHub(restoreParams)
+
+    expect(result.ok).toBe(true)
+    expect(result.data).toEqual(payload)
+  })
+
+  it('restoreFileFromGitHub: returns ok:false on malformed JSON', async () => {
+    const badContent = toBase64('not valid json {{{')
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ content: badContent, encoding: 'base64' }),
+    })
+
+    await expect(restoreFileFromGitHub(restoreParams)).rejects.toThrow()
+  })
+})
+
+describe('getFileShaForPathApi', () => {
+  it('getFileShaForPathApi: returns sha on 200', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ sha: 'deadbeef123' }),
+    })
+
+    const sha = await getFileShaForPathApi('ghp_test', 'owner', 'repo', 'path.json')
+
+    expect(sha).toBe('deadbeef123')
+  })
+
+  it('getFileShaForPathApi: returns null on 404', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const sha = await getFileShaForPathApi('ghp_test', 'owner', 'repo', 'path.json')
+
+    expect(sha).toBeNull()
+  })
+
+  it('getFileShaForPathApi: throws on 401', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 })
+
+    await expect(getFileShaForPathApi('ghp_test', 'owner', 'repo', 'path.json')).rejects.toThrow(
+      'Invalid token',
+    )
+  })
+})
+
+describe('testConnectionApi', () => {
+  it('testConnectionApi: returns ok:true with message on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({}),
+      json: async () => ({ full_name: 'owner/repo', private: true, permissions: { push: true } }),
+    })
+
+    const result = await testConnectionApi('ghp_test', 'owner', 'repo')
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('owner/repo')
+  })
+
+  it('testConnectionApi: returns warning for public repo', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({}),
+      json: async () => ({ full_name: 'owner/repo', private: false, permissions: { push: true } }),
+    })
+
+    const result = await testConnectionApi('ghp_test', 'owner', 'repo')
+
+    expect(result.ok).toBe(true)
+    expect(result.warnings).toContain('This repository is public. Backups may expose sensitive financial data.')
+  })
+
+  it('testConnectionApi: returns ok:false on 404', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      headers: new Headers({}),
+      json: async () => ({}),
+    })
+
+    const result = await testConnectionApi('ghp_test', 'owner', 'repo')
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('not found')
+  })
+})
+
+describe('fetchCommitHistory', () => {
+  it('fetchCommitHistory: parses commit array correctly', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          sha: 'abcdef1234567890',
+          commit: { message: 'sync: Jan 1', author: { date: '2025-01-01T00:00:00Z' } },
+          html_url: 'https://github.com/owner/repo/commit/abcdef1',
+        },
+      ],
+    })
+
+    const commits = await fetchCommitHistory('ghp_test', 'owner', 'repo', 'data/finance.json')
+
+    expect(commits).toHaveLength(1)
+    expect(commits[0]).toEqual({
+      sha: 'abcdef1',
+      message: 'sync: Jan 1',
+      date: '2025-01-01T00:00:00Z',
+      url: 'https://github.com/owner/repo/commit/abcdef1',
+    })
+  })
+
+  it('fetchCommitHistory: returns empty array on error', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    const commits = await fetchCommitHistory('ghp_test', 'owner', 'repo', 'data/finance.json')
+
+    expect(commits).toEqual([])
+  })
+})

--- a/src/hooks/useGitHubSyncApi.test.ts
+++ b/src/hooks/useGitHubSyncApi.test.ts
@@ -157,9 +157,7 @@ describe('getFileShaForPathApi', () => {
   it('getFileShaForPathApi: throws on 401', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 401 })
 
-    await expect(getFileShaForPathApi('ghp_test', 'owner', 'repo', 'path.json')).rejects.toThrow(
-      'Invalid token',
-    )
+    await expect(getFileShaForPathApi('ghp_test', 'owner', 'repo', 'path.json')).rejects.toThrow('Invalid token')
   })
 })
 

--- a/src/hooks/useGitHubSyncApi.ts
+++ b/src/hooks/useGitHubSyncApi.ts
@@ -1,0 +1,59 @@
+import { toBase64 } from './base64Utils'
+
+export interface SyncFileParams {
+  token: string
+  owner: string
+  repo: string
+  filePath: string
+  data: object
+  message?: string
+  messagePrefix: string
+  getFileSha: () => Promise<string | null>
+}
+
+const apiHeaders = (token: string): Record<string, string> => ({
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'Content-Type': 'application/json',
+})
+
+export async function syncFileToGitHub(params: SyncFileParams): Promise<{ ok: boolean; error?: string }> {
+  const { token, owner, repo, filePath, data, message, messagePrefix, getFileSha } = params
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const prettyJson = JSON.stringify(data, null, 2)
+      const content = toBase64(prettyJson)
+      const sha = await getFileSha()
+      const commitMessage =
+        message ||
+        `${messagePrefix}: ${new Date().toLocaleString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        })}`
+      const body: Record<string, string> = { message: commitMessage, content }
+      if (sha) body.sha = sha
+      const res = await fetch(
+        `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`,
+        { method: 'PUT', headers: apiHeaders(token), body: JSON.stringify(body) },
+      )
+      if ((res.status === 409 || res.status === 422) && attempt < 2) {
+        await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
+        continue
+      }
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        return { ok: false, error: (err as { message?: string }).message || `GitHub API error: ${res.status}` }
+      }
+      return { ok: true }
+    } catch (e) {
+      if (attempt === 2) {
+        return { ok: false, error: e instanceof Error ? e.message : String(e) }
+      }
+    }
+  }
+  return { ok: false, error: 'Unexpected: exhausted retries' }
+}

--- a/src/hooks/useGitHubSyncApi.ts
+++ b/src/hooks/useGitHubSyncApi.ts
@@ -1,4 +1,5 @@
 import { fromBase64, toBase64 } from './base64Utils'
+import type { CommitEntry, ConnectionTestResult } from './githubSyncTypes'
 
 export interface SyncFileParams {
   token: string
@@ -36,10 +37,11 @@ export async function syncFileToGitHub(params: SyncFileParams): Promise<{ ok: bo
         })}`
       const body: Record<string, string> = { message: commitMessage, content }
       if (sha) body.sha = sha
-      const res = await fetch(
-        `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`,
-        { method: 'PUT', headers: apiHeaders(token), body: JSON.stringify(body) },
-      )
+      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${filePath}`, {
+        method: 'PUT',
+        headers: apiHeaders(token),
+        body: JSON.stringify(body),
+      })
       if ((res.status === 409 || res.status === 422) && attempt < 2) {
         await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
         continue
@@ -64,6 +66,7 @@ export interface RestoreFileParams {
   repo: string
   filePath: string
   ref?: string
+  checkEncoding?: boolean
 }
 
 export interface RestoreFileResult {
@@ -73,7 +76,7 @@ export interface RestoreFileResult {
 }
 
 export async function restoreFileFromGitHub(params: RestoreFileParams): Promise<RestoreFileResult> {
-  const { token, owner, repo, filePath, ref } = params
+  const { token, owner, repo, filePath, ref, checkEncoding } = params
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}${ref ? `?ref=${ref}` : ''}`
   const res = await fetch(url, {
     headers: {
@@ -84,9 +87,96 @@ export async function restoreFileFromGitHub(params: RestoreFileParams): Promise<
   })
   if (!res.ok) return { ok: false, status: res.status }
   const json = await res.json()
-  const content = (json as { content?: string }).content
-  if (typeof content !== 'string') return { ok: false }
-  const decoded = fromBase64(content.replace(/\n/g, ''))
+  const file = json as { content?: string; encoding?: string }
+  if (checkEncoding && (!file.content || file.encoding !== 'base64')) return { ok: false }
+  if (!checkEncoding && typeof file.content !== 'string') return { ok: false }
+  const decoded = fromBase64(file.content!.replace(/\n/g, ''))
   const parsed = JSON.parse(decoded)
   return { ok: true, data: parsed }
+}
+
+export async function getFileShaForPathApi(
+  token: string,
+  owner: string,
+  repo: string,
+  path: string,
+): Promise<string | null> {
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    cache: 'no-store',
+  })
+  if (res.status === 404) return null
+  if (res.status === 401) throw new Error('Invalid token — check the token is correct and not expired.')
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status}`)
+  const data = await res.json()
+  return data.sha as string
+}
+
+export async function testConnectionApi(token: string, owner: string, repo: string): Promise<ConnectionTestResult> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+      headers: apiHeaders(token),
+    })
+    if (res.status === 404)
+      return {
+        ok: false,
+        message:
+          'Repository not found — if it\'s private, ensure the token has access to private repositories (classic token needs "repo" scope; fine-grained token needs "Contents: Read & Write").',
+        warnings: [],
+      }
+    if (res.status === 401)
+      return { ok: false, message: 'Invalid token — check the token is correct and not expired.', warnings: [] }
+    if (!res.ok) return { ok: false, message: `GitHub API error: ${res.status}`, warnings: [] }
+
+    const warnings: string[] = []
+    const scopes = res.headers.get('x-oauth-scopes')
+    const repoData = (await res.json()) as {
+      full_name: string
+      private?: boolean
+      permissions?: { push?: boolean }
+    }
+
+    if (repoData.private === false) {
+      warnings.push('This repository is public. Backups may expose sensitive financial data.')
+    }
+    if (repoData.permissions && repoData.permissions.push === false) {
+      warnings.push('Token does not appear to have write access to this repository.')
+    }
+    if (scopes && scopes.includes('repo')) {
+      warnings.push('Token has broad repo scope. Prefer a fine-grained token limited to one backup repo.')
+    }
+    return { ok: true, message: `Connected to ${repoData.full_name}`, warnings }
+  } catch {
+    return { ok: false, message: 'Network error. Check your connection.', warnings: [] }
+  }
+}
+
+export async function fetchCommitHistory(
+  token: string,
+  owner: string,
+  repo: string,
+  filePath: string,
+): Promise<CommitEntry[]> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/commits?path=${encodeURIComponent(filePath)}&per_page=100`,
+      { headers: apiHeaders(token) },
+    )
+    if (!res.ok) return []
+    const commits = await res.json()
+    return (commits as { sha: string; commit: { message: string; author: { date: string } }; html_url: string }[]).map(
+      c => ({
+        sha: (c.sha as string).slice(0, 7),
+        message: c.commit.message as string,
+        date: c.commit.author.date as string,
+        url: c.html_url as string,
+      }),
+    )
+  } catch {
+    return []
+  }
 }

--- a/src/hooks/useGitHubSyncApi.ts
+++ b/src/hooks/useGitHubSyncApi.ts
@@ -1,4 +1,4 @@
-import { toBase64 } from './base64Utils'
+import { fromBase64, toBase64 } from './base64Utils'
 
 export interface SyncFileParams {
   token: string
@@ -56,4 +56,37 @@ export async function syncFileToGitHub(params: SyncFileParams): Promise<{ ok: bo
     }
   }
   return { ok: false, error: 'Unexpected: exhausted retries' }
+}
+
+export interface RestoreFileParams {
+  token: string
+  owner: string
+  repo: string
+  filePath: string
+  ref?: string
+}
+
+export interface RestoreFileResult {
+  ok: boolean
+  status?: number
+  data?: unknown
+}
+
+export async function restoreFileFromGitHub(params: RestoreFileParams): Promise<RestoreFileResult> {
+  const { token, owner, repo, filePath, ref } = params
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${filePath}${ref ? `?ref=${ref}` : ''}`
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!res.ok) return { ok: false, status: res.status }
+  const json = await res.json()
+  const content = (json as { content?: string }).content
+  if (typeof content !== 'string') return { ok: false }
+  const decoded = fromBase64(content.replace(/\n/g, ''))
+  const parsed = JSON.parse(decoded)
+  return { ok: true, data: parsed }
 }

--- a/src/hooks/useGitHubSyncRestore.ts
+++ b/src/hooks/useGitHubSyncRestore.ts
@@ -1,17 +1,7 @@
 import { useCallback } from 'react'
 
-import {
-  restoreFileFromGitHub,
-  testConnectionApi,
-  fetchCommitHistory,
-} from './useGitHubSyncApi'
-import type {
-  GitHubSyncConfig,
-  CommitEntry,
-  ConnectionTestResult,
-  RestoreResult,
-  SyncStatus,
-} from './githubSyncTypes'
+import { restoreFileFromGitHub, testConnectionApi, fetchCommitHistory } from './useGitHubSyncApi'
+import type { GitHubSyncConfig, CommitEntry, ConnectionTestResult, RestoreResult, SyncStatus } from './githubSyncTypes'
 
 export interface RestoreHookParams {
   activeToken: string

--- a/src/hooks/useGitHubSyncRestore.ts
+++ b/src/hooks/useGitHubSyncRestore.ts
@@ -1,0 +1,189 @@
+import { useCallback } from 'react'
+
+import {
+  restoreFileFromGitHub,
+  testConnectionApi,
+  fetchCommitHistory,
+} from './useGitHubSyncApi'
+import type {
+  GitHubSyncConfig,
+  CommitEntry,
+  ConnectionTestResult,
+  RestoreResult,
+  SyncStatus,
+} from './githubSyncTypes'
+
+export interface RestoreHookParams {
+  activeToken: string
+  config: GitHubSyncConfig
+  isConfigured: boolean
+  dataFilePath: string
+  toolsFilePath: string
+  allocationFilePath: string
+  taxesFilePath: string
+  setHistory: (h: CommitEntry[]) => void
+  setSyncStatus: (s: SyncStatus) => void
+  setLastSyncAt: (s: string | null) => void
+  setLastError: (s: string | null) => void
+}
+
+export const useGitHubSyncRestore = (params: RestoreHookParams) => {
+  const {
+    activeToken,
+    config,
+    isConfigured,
+    dataFilePath,
+    toolsFilePath,
+    allocationFilePath,
+    taxesFilePath,
+    setHistory,
+    setSyncStatus,
+    setLastSyncAt,
+    setLastError,
+  } = params
+
+  const restoreLatest = useCallback(async (): Promise<RestoreResult> => {
+    if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
+    try {
+      const result = await restoreFileFromGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: config.filePath,
+      })
+      if (!result.ok) {
+        if (result.status === 404) return { ok: false, message: 'Backup file not found in repository.' }
+        if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
+        return { ok: false, message: 'Backup file format is not supported.' }
+      }
+      return { ok: true, message: 'Latest backup restored from GitHub.', data: result.data }
+    } catch {
+      return { ok: false, message: 'Could not restore backup from GitHub.' }
+    }
+  }, [activeToken, config.owner, config.repo, config.filePath, isConfigured])
+
+  const restoreDataLatest = useCallback(async (): Promise<RestoreResult> => {
+    if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
+    try {
+      const result = await restoreFileFromGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: dataFilePath,
+      })
+      if (!result.ok) {
+        if (result.status === 404) return { ok: true, message: 'No data file found.', data: null }
+        if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
+        return { ok: false, message: 'Data file format is not supported.' }
+      }
+      return { ok: true, message: 'Data file restored.', data: result.data }
+    } catch {
+      return { ok: false, message: 'Could not restore data file from GitHub.' }
+    }
+  }, [activeToken, config.owner, config.repo, dataFilePath, isConfigured])
+
+  const restoreToolsLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
+    if (!isConfigured) return { ok: false }
+    try {
+      const result = await restoreFileFromGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: toolsFilePath,
+      })
+      return result.ok ? { ok: true, data: result.data } : { ok: false }
+    } catch {
+      return { ok: false }
+    }
+  }, [activeToken, config.owner, config.repo, toolsFilePath, isConfigured])
+
+  const restoreAllocationLatest = useCallback(async (): Promise<{ ok: boolean; data?: unknown }> => {
+    if (!isConfigured) return { ok: false }
+    try {
+      const result = await restoreFileFromGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: allocationFilePath,
+      })
+      return result.ok ? { ok: true, data: result.data } : { ok: false }
+    } catch {
+      return { ok: false }
+    }
+  }, [activeToken, config.owner, config.repo, allocationFilePath, isConfigured])
+
+  const restoreTaxesLatest = useCallback(async (): Promise<RestoreResult> => {
+    if (!isConfigured) return { ok: false, message: '' }
+    try {
+      const result = await restoreFileFromGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: taxesFilePath,
+      })
+      return result.ok ? { ok: true, message: '', data: result.data } : { ok: false, message: '' }
+    } catch {
+      return { ok: false, message: '' }
+    }
+  }, [activeToken, config.owner, config.repo, taxesFilePath, isConfigured])
+
+  const restoreFromCommit = useCallback(
+    async (commitSha: string): Promise<RestoreResult> => {
+      if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
+      try {
+        const result = await restoreFileFromGitHub({
+          token: activeToken,
+          owner: config.owner,
+          repo: config.repo,
+          filePath: config.filePath,
+          ref: commitSha,
+          checkEncoding: true,
+        })
+        if (!result.ok) {
+          if (result.status === 404) return { ok: false, message: 'Backup file not found in this commit.' }
+          if (result.status) return { ok: false, message: `GitHub API error: ${result.status}` }
+          return { ok: false, message: 'Backup file format is not supported.' }
+        }
+        return { ok: true, message: `Restored from commit ${commitSha.slice(0, 7)}.`, data: result.data }
+      } catch {
+        return { ok: false, message: 'Could not restore backup from GitHub.' }
+      }
+    },
+    [activeToken, config.filePath, config.owner, config.repo, isConfigured],
+  )
+
+  const markRestored = useCallback(
+    (clearAllDirty: () => void) => {
+      setLastSyncAt(new Date().toISOString())
+      setSyncStatus('success')
+      clearAllDirty()
+      setLastError(null)
+    },
+    [setSyncStatus, setLastSyncAt, setLastError],
+  )
+
+  const fetchHistory = useCallback(async (): Promise<void> => {
+    if (!isConfigured) return
+    const commits = await fetchCommitHistory(activeToken, config.owner, config.repo, config.filePath)
+    setHistory(commits)
+  }, [activeToken, config.filePath, config.owner, config.repo, isConfigured, setHistory])
+
+  const testConnection = useCallback(async (): Promise<ConnectionTestResult> => {
+    if (!activeToken || !config.owner || !config.repo) {
+      return { ok: false, message: 'Fill in token, owner, and repository first.', warnings: [] }
+    }
+    return testConnectionApi(activeToken, config.owner, config.repo)
+  }, [activeToken, config.owner, config.repo])
+
+  return {
+    restoreLatest,
+    restoreDataLatest,
+    restoreToolsLatest,
+    restoreAllocationLatest,
+    restoreTaxesLatest,
+    restoreFromCommit,
+    markRestored,
+    fetchHistory,
+    testConnection,
+  }
+}

--- a/src/hooks/useGitHubSyncRestore.ts
+++ b/src/hooks/useGitHubSyncRestore.ts
@@ -42,7 +42,7 @@ export const useGitHubSyncRestore = (params: RestoreHookParams) => {
     setLastError,
   } = params
 
-  const restoreLatest = useCallback(async (): Promise<RestoreResult> => {
+  const restoreGoalsLatest = useCallback(async (): Promise<RestoreResult> => {
     if (!isConfigured) return { ok: false, message: 'Connect and unlock token first.' }
     try {
       const result = await restoreFileFromGitHub({
@@ -176,7 +176,7 @@ export const useGitHubSyncRestore = (params: RestoreHookParams) => {
   }, [activeToken, config.owner, config.repo])
 
   return {
-    restoreLatest,
+    restoreGoalsLatest,
     restoreDataLatest,
     restoreToolsLatest,
     restoreAllocationLatest,

--- a/src/hooks/useGitHubSyncUpload.ts
+++ b/src/hooks/useGitHubSyncUpload.ts
@@ -34,12 +34,12 @@ export const useGitHubSyncUpload = (params: SyncHookParams) => {
     setLastError,
   } = params
 
-  const lastSyncedJsonRef = useRef<string | null>(null)
+  const lastSyncedGoalsJsonRef = useRef<string | null>(null)
   const lastSyncedDataJsonRef = useRef<string | null>(null)
   const pendingDataRef = useRef<object | null>(null)
   const pendingDataFileRef = useRef<object | null>(null)
 
-  const syncNow = useCallback(
+  const syncGoalsNow = useCallback(
     async (data: object, message?: string): Promise<void> => {
       if (!isConfigured) return
       setSyncStatus('syncing')
@@ -55,7 +55,7 @@ export const useGitHubSyncUpload = (params: SyncHookParams) => {
         getFileSha: () => getFileShaForPath(config.filePath),
       })
       if (result.ok) {
-        lastSyncedJsonRef.current = (() => {
+        lastSyncedGoalsJsonRef.current = (() => {
           const { exportedAt: _, ...rest } = data as Record<string, unknown>
           return JSON.stringify(rest)
         })()
@@ -169,12 +169,12 @@ export const useGitHubSyncUpload = (params: SyncHookParams) => {
   )
 
   return {
-    syncNow,
+    syncGoalsNow,
     syncDataNow,
     syncToolsNow,
     syncAllocationNow,
     syncTaxesNow,
-    lastSyncedJsonRef,
+    lastSyncedGoalsJsonRef,
     lastSyncedDataJsonRef,
     pendingDataRef,
     pendingDataFileRef,

--- a/src/hooks/useGitHubSyncUpload.ts
+++ b/src/hooks/useGitHubSyncUpload.ts
@@ -1,0 +1,182 @@
+import { useCallback, useRef } from 'react'
+
+import { syncFileToGitHub } from './useGitHubSyncApi'
+import type { GitHubSyncConfig, SyncDomain, SyncStatus } from './githubSyncTypes'
+
+export interface SyncHookParams {
+  activeToken: string
+  config: GitHubSyncConfig
+  isConfigured: boolean
+  dataFilePath: string
+  toolsFilePath: string
+  allocationFilePath: string
+  taxesFilePath: string
+  getFileShaForPath: (path: string) => Promise<string | null>
+  clearDirty: (domain: SyncDomain) => void
+  setSyncStatus: (s: SyncStatus) => void
+  setLastSyncAt: (s: string | null) => void
+  setLastError: (s: string | null) => void
+}
+
+export const useGitHubSyncUpload = (params: SyncHookParams) => {
+  const {
+    activeToken,
+    config,
+    isConfigured,
+    dataFilePath,
+    toolsFilePath,
+    allocationFilePath,
+    taxesFilePath,
+    getFileShaForPath,
+    clearDirty,
+    setSyncStatus,
+    setLastSyncAt,
+    setLastError,
+  } = params
+
+  const lastSyncedJsonRef = useRef<string | null>(null)
+  const lastSyncedDataJsonRef = useRef<string | null>(null)
+  const pendingDataRef = useRef<object | null>(null)
+  const pendingDataFileRef = useRef<object | null>(null)
+
+  const syncNow = useCallback(
+    async (data: object, message?: string): Promise<void> => {
+      if (!isConfigured) return
+      setSyncStatus('syncing')
+      setLastError(null)
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: config.filePath,
+        data,
+        message,
+        messagePrefix: 'Auto-save',
+        getFileSha: () => getFileShaForPath(config.filePath),
+      })
+      if (result.ok) {
+        lastSyncedJsonRef.current = (() => {
+          const { exportedAt: _, ...rest } = data as Record<string, unknown>
+          return JSON.stringify(rest)
+        })()
+        setSyncStatus('success')
+        setLastSyncAt(new Date().toISOString())
+        clearDirty('goals')
+      } else {
+        setSyncStatus('error')
+        setLastError(result.error || 'Sync failed')
+        throw new Error(result.error || 'Sync failed')
+      }
+    },
+    [activeToken, config.owner, config.repo, config.filePath, getFileShaForPath, isConfigured, clearDirty, setSyncStatus, setLastSyncAt, setLastError],
+  )
+
+  const syncDataNow = useCallback(
+    async (data: object, message?: string): Promise<void> => {
+      if (!isConfigured) return
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: dataFilePath,
+        data,
+        message,
+        messagePrefix: 'Data sync',
+        getFileSha: () => getFileShaForPath(dataFilePath),
+      })
+      if (result.ok) {
+        lastSyncedDataJsonRef.current = (() => {
+          const { exportedAt: _, ...rest } = data as Record<string, unknown>
+          return JSON.stringify(rest)
+        })()
+        pendingDataFileRef.current = null
+        clearDirty('data')
+      } else {
+        console.error('Data file sync error:', result.error)
+        throw new Error(result.error || 'Data sync failed')
+      }
+    },
+    [activeToken, config.owner, config.repo, dataFilePath, getFileShaForPath, isConfigured, clearDirty],
+  )
+
+  const syncToolsNow = useCallback(
+    async (data: object, message?: string): Promise<void> => {
+      if (!isConfigured) return
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: toolsFilePath,
+        data,
+        message,
+        messagePrefix: 'Tools sync',
+        getFileSha: () => getFileShaForPath(toolsFilePath),
+      })
+      if (result.ok) {
+        clearDirty('tools')
+      } else {
+        console.error('Tools file sync error:', result.error)
+        throw new Error(result.error || 'Tools sync failed')
+      }
+    },
+    [activeToken, config.owner, config.repo, toolsFilePath, getFileShaForPath, isConfigured, clearDirty],
+  )
+
+  const syncAllocationNow = useCallback(
+    async (data: object, message?: string): Promise<void> => {
+      if (!isConfigured) return
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: allocationFilePath,
+        data,
+        message,
+        messagePrefix: 'Allocation sync',
+        getFileSha: () => getFileShaForPath(allocationFilePath),
+      })
+      if (result.ok) {
+        clearDirty('allocation')
+      } else {
+        console.error('Allocation file sync error:', result.error)
+        throw new Error(result.error || 'Allocation sync failed')
+      }
+    },
+    [activeToken, config.owner, config.repo, allocationFilePath, getFileShaForPath, isConfigured, clearDirty],
+  )
+
+  const syncTaxesNow = useCallback(
+    async (data: object, message?: string): Promise<void> => {
+      if (!isConfigured) return
+      const result = await syncFileToGitHub({
+        token: activeToken,
+        owner: config.owner,
+        repo: config.repo,
+        filePath: taxesFilePath,
+        data,
+        message,
+        messagePrefix: 'Taxes sync',
+        getFileSha: () => getFileShaForPath(taxesFilePath),
+      })
+      if (result.ok) {
+        clearDirty('taxes')
+      } else {
+        console.error('Taxes file sync error:', result.error)
+        throw new Error(result.error || 'Taxes sync failed')
+      }
+    },
+    [activeToken, config.owner, config.repo, taxesFilePath, getFileShaForPath, isConfigured, clearDirty],
+  )
+
+  return {
+    syncNow,
+    syncDataNow,
+    syncToolsNow,
+    syncAllocationNow,
+    syncTaxesNow,
+    lastSyncedJsonRef,
+    lastSyncedDataJsonRef,
+    pendingDataRef,
+    pendingDataFileRef,
+  }
+}

--- a/src/hooks/useGitHubSyncUpload.ts
+++ b/src/hooks/useGitHubSyncUpload.ts
@@ -68,7 +68,18 @@ export const useGitHubSyncUpload = (params: SyncHookParams) => {
         throw new Error(result.error || 'Sync failed')
       }
     },
-    [activeToken, config.owner, config.repo, config.filePath, getFileShaForPath, isConfigured, clearDirty, setSyncStatus, setLastSyncAt, setLastError],
+    [
+      activeToken,
+      config.owner,
+      config.repo,
+      config.filePath,
+      getFileShaForPath,
+      isConfigured,
+      clearDirty,
+      setSyncStatus,
+      setLastSyncAt,
+      setLastError,
+    ],
   )
 
   const syncDataNow = useCallback(


### PR DESCRIPTION
## Summary

Splits the 806-line `useGitHubSync.ts` monolith into focused, single-responsibility modules:

| Module | Responsibility | Lines |
|--------|---------------|-------|
| `base64Utils.ts` | Base64 encode/decode | ~15 |
| `tokenCrypto.ts` | Token encryption/decryption (AES-GCM) | ~30 |
| `githubSyncTypes.ts` | Shared type definitions | ~40 |
| `githubSyncConfig.ts` | Constants and config loading | ~29 |
| `useGitHubSyncApi.ts` | Pure async GitHub API functions | ~182 |
| `useGitHubSyncUpload.ts` | Upload/sync sub-hook | ~183 |
| `useGitHubSyncRestore.ts` | Restore sub-hook | ~190 |
| `useGitHubSync.ts` | Orchestrator (composes sub-hooks, public API) | ~301 |

### Key decisions
- **Public API unchanged** — all 138 existing tests pass without modification
- **Internal names are domain-specific** (e.g. `syncGoalsNow`, `restoreGoalsLatest`) while the orchestrator aliases them back to the generic public API names
- **3-file split pattern**: upload hook + restore hook + orchestrator re-export

### Test coverage added
- 22 unit tests (tokenCrypto, base64Utils, useGitHubSyncApi)
- 5 Playwright E2E tests (full sync journey, config persistence, status transitions, restore roundtrip, error handling)

Fixes #180