### PR TITLE
fix: include budget in sync domain loop so uploads reach GitHub

### DIFF
--- a/src/components/SidebarNavigation.tsx
+++ b/src/components/SidebarNavigation.tsx
@@ -18,18 +18,17 @@ const SidebarNavigation: FC<NavigationProps> = ({ currentPage, setCurrentPage })
   const ghContext = useGitHubSyncContext()
   const { handleSyncNow, dirtyFlags } = ghContext
   const gh = useMemo(() => ghContext, [ghContext])
-  const { budget: budgetDirty, taxes: taxesDirty } = dirtyFlags
+  const { taxes: taxesDirty } = dirtyFlags
   const budgetSync = useBudgetSync()
   const taxSync = useTaxSync()
   const combinedSyncNow = useCallback(
     async (data: object, message?: string, forceFull?: boolean) => {
       await Promise.allSettled([
         handleSyncNow(data, message, forceFull),
-        ...(forceFull || budgetDirty ? [budgetSync.syncBudgetNow()] : []),
         ...(forceFull || taxesDirty ? [taxSync.syncTaxNow(message)] : []),
       ])
     },
-    [handleSyncNow, budgetDirty, taxesDirty, budgetSync, taxSync],
+    [handleSyncNow, taxesDirty, taxSync],
   )
   const combinedRestore = useCallback(
     async (data: unknown) => {

--- a/src/contexts/BudgetSyncContext.test.tsx
+++ b/src/contexts/BudgetSyncContext.test.tsx
@@ -50,9 +50,7 @@ describe('BudgetSyncContext', () => {
       vi.useRealTimers()
     })
 
-    it('clears budget dirty flag when not configured (skips upload, clears flag)', async () => {
-      // When isConfigured is false, syncBudgetNow skips upload and still calls
-      // clearDirty('budget'). This is by design: nothing to sync = clear the flag.
+    it('keeps budget dirty flag when not configured', async () => {
       const { result } = renderHook(() => ({ budget: useBudgetSync(), sync: useGitHubSyncContext() }), { wrapper })
 
       // Advance past the 3-second dirty-ready gate in useGitHubSync
@@ -60,7 +58,7 @@ describe('BudgetSyncContext', () => {
         await vi.advanceTimersByTimeAsync(3100)
       })
 
-      // Mark budget dirty so we can verify it gets cleared
+      // Mark budget dirty so we can verify it remains dirty
       act(() => {
         result.current.sync.markDirty('budget')
       })
@@ -71,7 +69,7 @@ describe('BudgetSyncContext', () => {
         await result.current.budget.syncBudgetNow()
       })
 
-      expect(result.current.sync.dirtyFlags.budget).toBe(false)
+      expect(result.current.sync.dirtyFlags.budget).toBe(true)
     })
   })
 
@@ -379,10 +377,10 @@ describe('BudgetSyncContext', () => {
     })
   })
 
-  /* ── syncBudgetNow when not configured — clearDirty still runs (line 46-47) ── */
+  /* ── syncBudgetNow when not configured — clearDirty is skipped ── */
 
   describe('syncBudgetNow clearDirty when not configured', () => {
-    it('clears dirty flag even when isConfigured is false (line 46)', async () => {
+    it('does not clear dirty flag when isConfigured is false', async () => {
       vi.useFakeTimers()
 
       const { result } = renderHook(() => ({ budget: useBudgetSync(), sync: useGitHubSyncContext() }), { wrapper })
@@ -394,7 +392,7 @@ describe('BudgetSyncContext', () => {
       // Not configured
       expect(result.current.sync.isConfigured).toBe(false)
 
-      // Mark dirty then sync — should clear even without being configured
+      // Mark dirty then sync — should remain dirty without a configured sync
       act(() => {
         result.current.sync.markDirty('budget')
       })
@@ -404,7 +402,7 @@ describe('BudgetSyncContext', () => {
         await result.current.budget.syncBudgetNow()
       })
 
-      expect(result.current.sync.dirtyFlags.budget).toBe(false)
+      expect(result.current.sync.dirtyFlags.budget).toBe(true)
 
       vi.useRealTimers()
     })

--- a/src/contexts/BudgetSyncContext.tsx
+++ b/src/contexts/BudgetSyncContext.tsx
@@ -42,8 +42,8 @@ export const BudgetSyncProvider: FC<{ children: ReactNode }> = ({ children }) =>
       const budgetStore = loadBudgetStore()
       await uploadBudgetConfig(config, activeToken, getBudgetConfigData(budgetStore))
       await syncAllBudgetCSVs(config, activeToken, budgetStore.csvs)
+      clearDirty('budget')
     }
-    clearDirty('budget')
   }, [config, activeToken, isConfigured, clearDirty])
 
   const restoreBudgetFromGitHub = useCallback(async (): Promise<void> => {

--- a/src/contexts/GitHubSyncContext.test.tsx
+++ b/src/contexts/GitHubSyncContext.test.tsx
@@ -655,6 +655,25 @@ describe('GitHubSyncContext', () => {
       // syncProgress is set then cleared after 2s timeout
       expect(result.current.syncStatus).toBe('success')
     })
+
+    it('does not mark success when taxes are the only dirty domain', async () => {
+      const { result } = renderHook(() => useGitHubSyncContext(), { wrapper })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3100)
+      })
+
+      act(() => {
+        result.current.markDirty('taxes')
+      })
+
+      await act(async () => {
+        await result.current.handleSyncNow({}, undefined, false)
+      })
+
+      expect(result.current.syncStatus).toBe('idle')
+      expect(result.current.lastError).toBeNull()
+    })
   })
 
   /* ── syncTaxesNow via context ──────────────────────────────────── */

--- a/src/contexts/GitHubSyncContext.tsx
+++ b/src/contexts/GitHubSyncContext.tsx
@@ -13,6 +13,8 @@ import { useSettings } from './SettingsContext'
 import { useGoals } from './GoalsContext'
 import type { GwGoal } from '../types'
 import type { Account, BalanceEntry } from '../pages/data/types'
+import { loadBudgetStore, getBudgetConfigData } from '../pages/budget/utils/budgetStorage'
+import { syncAllBudgetCSVs, uploadBudgetConfig } from '../pages/budget/utils/budgetGitHubSync'
 import { appStorage } from '../utils/appStorage'
 import { getStorageItem, setStorageItem } from '../utils/storage'
 import { validateImportPayload } from '../utils/importValidator'
@@ -65,6 +67,8 @@ const DOMAIN_LABELS: Record<string, string> = {
   data: 'Balances',
   tools: 'Tools',
   allocation: 'Allocation',
+  budget: 'Budget',
+  taxes: 'Taxes',
 }
 
 const getDataSnapshot = (): { accounts: Account[]; balances: BalanceEntry[] } => {
@@ -154,14 +158,22 @@ export const GitHubSyncProvider: FC<{ children: ReactNode }> = ({ children }) =>
     async (_data: object, message?: string, forceFull?: boolean): Promise<void> => {
       if (syncStatus === 'syncing') return
 
-      const domains: Array<'goals' | 'data' | 'tools' | 'allocation'> = ['goals', 'data', 'tools', 'allocation']
+      const domains: Array<'goals' | 'data' | 'tools' | 'allocation' | 'budget'> = [
+        'goals',
+        'data',
+        'tools',
+        'allocation',
+        'budget',
+      ]
       const dirtySnapshot = { ...ghDirtyFlags }
       const toSync = forceFull ? domains : domains.filter(d => dirtySnapshot[d])
 
       if (toSync.length === 0) {
-        ghSetSyncStatus('success')
-        ghSetLastSyncAt(new Date().toISOString())
-        ghSetLastError(null)
+        if (!dirtySnapshot.taxes) {
+          ghSetSyncStatus('success')
+          ghSetLastSyncAt(new Date().toISOString())
+          ghSetLastError(null)
+        }
         ghSetSyncProgress({ total: 0, completed: 0, current: '', errors: [], domains: [] })
         setTimeout(() => ghSetSyncProgress(null), 2000)
         return
@@ -238,6 +250,15 @@ export const GitHubSyncProvider: FC<{ children: ReactNode }> = ({ children }) =>
               )
               ghClearDirty('allocation')
               break
+            case 'budget': {
+              if (ghIsConfigured && ghActiveToken) {
+                const budgetStore = loadBudgetStore()
+                await uploadBudgetConfig(ghConfig, ghActiveToken, getBudgetConfigData(budgetStore))
+                await syncAllBudgetCSVs(ghConfig, ghActiveToken, budgetStore.csvs)
+                ghClearDirty('budget')
+              }
+              break
+            }
           }
         } catch (e) {
           const errMsg = `${DOMAIN_LABELS[domain]}: ${e instanceof Error ? e.message : String(e)}`
@@ -262,6 +283,9 @@ export const GitHubSyncProvider: FC<{ children: ReactNode }> = ({ children }) =>
       darkMode,
       allowCsvImport,
       syncNow,
+      ghConfig,
+      ghActiveToken,
+      ghIsConfigured,
       ghSyncDataNow,
       ghSyncToolsNow,
       ghSyncAllocationNow,


### PR DESCRIPTION
## Why

Uploading budget files and clicking "Sync" showed "everything is latest" without actually uploading anything. Budget data silently failed to reach GitHub.

## Root cause

`handleSyncNow` in `GitHubSyncContext` only iterated over `['goals', 'data', 'tools', 'allocation']` -- budget was excluded from the domain loop. When only budget was dirty, the `toSync` array was empty and the early-return path set sync status to "success" without uploading anything. A secondary bug: `clearDirty('budget')` was called unconditionally in `BudgetSyncContext`, clearing the dirty flag even when sync was skipped or failed.

## Approach

Three surgical changes across the sync layer:

- **GitHubSyncContext.tsx**: Added `'budget'` to the domains array, `DOMAIN_LABELS`, and a new switch case that uploads budget config + CSVs using the existing standalone utilities (`uploadBudgetConfig`, `syncAllBudgetCSVs`). Budget now gets unified progress tracking and error handling alongside the other domains. Also guards the empty-`toSync` early return against falsely reporting success when taxes is the only dirty domain.

- **BudgetSyncContext.tsx**: Moved `clearDirty('budget')` inside the `isConfigured` guard so the dirty flag only clears after a successful upload.

- **SidebarNavigation.tsx**: Removed the now-redundant `budgetSync.syncBudgetNow()` call from `combinedSyncNow` since budget is handled inside `handleSyncNow`.

## Notes

- Taxes remain handled separately in `combinedSyncNow` because `syncAllTaxFiles` needs `cryptoKey` from `EncryptionContext`, which is not available in `GitHubSyncContext` (parent provider).
- Budget sync utilities are standalone functions (not hooks), so importing them in `GitHubSyncContext` creates no circular dependency.
- Updated 2 test files: `BudgetSyncContext.test.tsx` expectations now verify the dirty flag persists when not configured, and `GitHubSyncContext.test.tsx` adds a regression test for taxes-only dirty not falsely reporting success.

## Validation

- `tsc --noEmit`: clean
- Unit tests: 3,552 passed (was 3,551 -- +1 regression test)
- E2E tests: 338 passed